### PR TITLE
feat: add --transcript option with exit-time save prompt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,13 +30,14 @@ Flat command (no subcommands). `--doctor` is the only "different mode"; everythi
 
 ```
 vo [--src LOCALE] [--dst LOCALE] [--no-mic] [--no-speaker]
-   [--voice-processing] [--doctor] [--json]
+   [--voice-processing] [--log PATH] [--doctor] [--json]
 ```
 
 - `--src` defaults to `Locale.current.identifier(.bcp47)`. Must be in `SpeechTranscriber.supportedLocales` (all regional, no bare `en` / `ja`). Unsupported values produce a helpful error suggesting matching regional variants.
 - `--dst` is optional. Without it, `vo` is transcribe-only and never calls `TranslationSession`.
 - `--voice-processing` enables AVAudioInputNode voice processing (echo cancellation + noise reduction). **Default off** because enabling it puts the OS audio session into communication mode and lowers system speaker volume. Use only when running mic + speaker on the same physical device without headphones.
 - `--json` forces JSONL output. Without it, auto-detects: TTY → ANSI redraw, non-TTY → JSONL.
+- `--log PATH` streams finalized chunks as JSONL into `PATH`. Without it, vo streams the same JSONL into a temp file under `TMPDIR` and at Ctrl-C asks `Save log to ./vo-<stamp>.jsonl? [Y/n/<path>]`. If the chosen target (or `PATH` itself) exists, vo prompts `Overwrite? [y/N]`. Memory usage stays bounded across long sessions because nothing is buffered.
 
 ## Architecture
 
@@ -84,6 +85,7 @@ The whole pipeline is one TaskGroup orchestrating two parallel channels (mic + s
 | `Doctor.swift` | `runDoctor(json:)`. Gathers OS info, speech model status, translation language list, input device list via the helpers below, then renders human text or JSON. |
 | `Locales.swift` | `collectSpeechLocales()` and `collectTranslationLanguages()`. Pure data collection, no I/O. |
 | `Devices.swift` | `collectInputDevices()`. Direct Core Audio enumeration via `AudioObjectGetPropertyData`. |
+| `SessionLog.swift` | Streaming JSONL log file. Two modes: explicit (`--log <path>` writes directly there) or temp (`TMPDIR` file moved/discarded on exit). Owns the overwrite-confirm and `Save log?` prompts. |
 
 ### Key invariants in `StreamRenderer`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,14 +30,14 @@ Flat command (no subcommands). `--doctor` is the only "different mode"; everythi
 
 ```
 vo [--src LOCALE] [--dst LOCALE] [--no-mic] [--no-speaker]
-   [--voice-processing] [--log PATH] [--doctor] [--json]
+   [--voice-processing] [--transcript PATH] [--doctor] [--json]
 ```
 
 - `--src` defaults to `Locale.current.identifier(.bcp47)`. Must be in `SpeechTranscriber.supportedLocales` (all regional, no bare `en` / `ja`). Unsupported values produce a helpful error suggesting matching regional variants.
 - `--dst` is optional. Without it, `vo` is transcribe-only and never calls `TranslationSession`.
 - `--voice-processing` enables AVAudioInputNode voice processing (echo cancellation + noise reduction). **Default off** because enabling it puts the OS audio session into communication mode and lowers system speaker volume. Use only when running mic + speaker on the same physical device without headphones.
 - `--json` forces JSONL output. Without it, auto-detects: TTY → ANSI redraw, non-TTY → JSONL.
-- `--log PATH` streams finalized chunks as JSONL into `PATH`. Without it, vo streams the same JSONL into a temp file under `TMPDIR` and at Ctrl-C asks `Save log to ./vo-<stamp>.jsonl? [Y/n/<path>]`. If the chosen target (or `PATH` itself) exists, vo prompts `Overwrite? [y/N]`. Memory usage stays bounded across long sessions because nothing is buffered.
+- `--transcript PATH` streams finalized chunks as JSONL into `PATH`. Without it, vo streams the same JSONL into a temp file under `TMPDIR` and at Ctrl-C asks `Save transcript to ./vo-<stamp>.jsonl? [Y/n/<path>]`. If the chosen target (or `PATH` itself) exists, vo prompts `Overwrite? [y/N]`. Memory usage stays bounded across long sessions because nothing is buffered.
 
 ## Architecture
 
@@ -85,7 +85,7 @@ The whole pipeline is one TaskGroup orchestrating two parallel channels (mic + s
 | `Doctor.swift` | `runDoctor(json:)`. Gathers OS info, speech model status, translation language list, input device list via the helpers below, then renders human text or JSON. |
 | `Locales.swift` | `collectSpeechLocales()` and `collectTranslationLanguages()`. Pure data collection, no I/O. |
 | `Devices.swift` | `collectInputDevices()`. Direct Core Audio enumeration via `AudioObjectGetPropertyData`. |
-| `SessionLog.swift` | Streaming JSONL log file. Two modes: explicit (`--log <path>` writes directly there) or temp (`TMPDIR` file moved/discarded on exit). Owns the overwrite-confirm and `Save log?` prompts. |
+| `SessionLog.swift` | Streaming JSONL transcript file. Two modes: explicit (`--transcript <path>` writes directly there) or temp (`TMPDIR` file moved/discarded on exit). Owns the overwrite-confirm and `Save transcript?` prompts. |
 
 ### Key invariants in `StreamRenderer`
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Translation lines are shown in dim text under the source. Pairs are emitted in s
 | `--no-speaker` | (off, speaker on) | Disable system audio capture |
 | `--voice-processing` | off | Apply echo cancellation on mic input |
 | `--json` | | Force JSONL output |
-| `--log <path>` | (none; prompts at exit in TTY) | Stream finalized chunks as JSONL to `<path>` incrementally. Skips the interactive save prompt |
+| `--transcript <path>` | (none; prompts at exit in TTY) | Stream finalized chunks as JSONL to `<path>` incrementally. Skips the interactive save prompt |
 | `--doctor` | | Print full environment diagnostics and exit |
 
 `vo --doctor` lists supported locales, installed speech models, available translation language pairs, and audio input devices. Run it first if something behaves unexpectedly.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Translation lines are shown in dim text under the source. Pairs are emitted in s
 | `--no-speaker` | (off, speaker on) | Disable system audio capture |
 | `--voice-processing` | off | Apply echo cancellation on mic input |
 | `--json` | | Force JSONL output |
+| `--log <path>` | (prompt at exit) | Save finalized chunks as JSONL to `<path>`. Skips the interactive save prompt |
 | `--doctor` | | Print full environment diagnostics and exit |
 
 `vo --doctor` lists supported locales, installed speech models, available translation language pairs, and audio input devices. Run it first if something behaves unexpectedly.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Translation lines are shown in dim text under the source. Pairs are emitted in s
 | `--no-speaker` | (off, speaker on) | Disable system audio capture |
 | `--voice-processing` | off | Apply echo cancellation on mic input |
 | `--json` | | Force JSONL output |
-| `--log <path>` | (prompt at exit) | Save finalized chunks as JSONL to `<path>`. Skips the interactive save prompt |
+| `--log <path>` | (none; prompts at exit in TTY) | Stream finalized chunks as JSONL to `<path>` incrementally. Skips the interactive save prompt |
 | `--doctor` | | Print full environment diagnostics and exit |
 
 `vo --doctor` lists supported locales, installed speech models, available translation language pairs, and audio input devices. Run it first if something behaves unexpectedly.

--- a/Sources/vo/Listen.swift
+++ b/Sources/vo/Listen.swift
@@ -8,7 +8,8 @@ func runListen(
     json: Bool,
     mic: Bool,
     speaker: Bool,
-    voiceProcessing: Bool
+    voiceProcessing: Bool,
+    log: String?
 ) async throws {
     guard mic || speaker else {
         throw ValidationError("Cannot disable both mic and speaker. Drop one of --no-mic / --no-speaker.")
@@ -19,11 +20,28 @@ func runListen(
 
     let mode = detectRenderMode(jsonForced: json)
     let isTTY = (mode == .tty)
+
+    // Stream JSONL to disk as utterances finalize, so memory stays bounded for long
+    // sessions. With --log we write straight to the user-specified path. Without it,
+    // we use a temp file and decide at shutdown whether to keep or discard.
+    let sessionLog = try SessionLog.open(explicitPath: log)
+
+    // If we throw out of this function before finalizeSession runs (e.g. the pipeline
+    // errors mid-stream), make sure no temp file is left behind. In explicit mode we
+    // leave the user-supplied file in place.
+    defer {
+        sessionLog.close()
+        if !sessionLog.isExplicit {
+            sessionLog.discard()
+        }
+    }
+
     let renderer = StreamRenderer(
         mode: mode,
         sourceLang: sourceLocale.identifier(.bcp47),
         targetLang: targetLocale?.identifier(.bcp47) ?? "",
-        translationEnabled: targetLocale != nil
+        translationEnabled: targetLocale != nil,
+        logSink: sessionLog
     )
 
     let pipeline = Pipeline(
@@ -45,10 +63,13 @@ func runListen(
         Task {
             await renderer.handle(.eof)
             await renderer.flush()
-            if isTTY {
-                let count = await renderer.utteranceCount
-                printSummary(count: count, duration: Date().timeIntervalSince(startedAt))
-            }
+            let count = await renderer.utteranceCount
+            await finalizeSession(
+                sessionLog: sessionLog,
+                isTTY: isTTY,
+                count: count,
+                duration: Date().timeIntervalSince(startedAt)
+            )
             Foundation.exit(0)
         }
     }
@@ -57,9 +78,29 @@ func runListen(
 
     try await pipeline.run()
 
+    let count = await renderer.utteranceCount
+    await finalizeSession(
+        sessionLog: sessionLog,
+        isTTY: isTTY,
+        count: count,
+        duration: Date().timeIntervalSince(startedAt)
+    )
+}
+
+/// Close the session log, run save/discard logic, then print the exit summary.
+/// Called from both the SIGINT handler and the natural-completion path.
+private func finalizeSession(
+    sessionLog: SessionLog,
+    isTTY: Bool,
+    count: Int,
+    duration: TimeInterval
+) async {
+    let status = resolveSessionLog(sessionLog: sessionLog, canPrompt: canPromptForLog())
     if isTTY {
-        let count = await renderer.utteranceCount
-        printSummary(count: count, duration: Date().timeIntervalSince(startedAt))
+        if let status { print(status) }
+        printSummary(count: count, duration: duration)
+    } else if let status, sessionLog.isExplicit {
+        FileHandle.standardError.write(Data((status + "\n").utf8))
     }
 }
 

--- a/Sources/vo/Listen.swift
+++ b/Sources/vo/Listen.swift
@@ -64,6 +64,10 @@ func runListen(
     let signalSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
     signalSource.setEventHandler {
         Task {
+            // Stop the audio sources before the save prompt blocks. Otherwise mic
+            // and speaker capture keep running for as long as the user is reading
+            // the prompt, which is wasted work and a small privacy footgun.
+            await pipeline.cancel()
             await renderer.handle(.eof)
             await renderer.flush()
             let count = await renderer.utteranceCount

--- a/Sources/vo/Listen.swift
+++ b/Sources/vo/Listen.swift
@@ -28,10 +28,13 @@ func runListen(
 
     // If we throw out of this function before finalizeSession runs (e.g. the pipeline
     // errors mid-stream), make sure no temp file is left behind. In explicit mode we
-    // leave the user-supplied file in place.
+    // leave the user-supplied file in place. We also skip discard when resolveSessionLog
+    // has flagged the temp file as preserved for manual recovery (move-target failure),
+    // since that is the one case where the temp file holding the captured data is what
+    // we want the user to find.
     defer {
         sessionLog.close()
-        if !sessionLog.isExplicit {
+        if !sessionLog.isExplicit && !sessionLog.preservedForRecovery {
             sessionLog.discard()
         }
     }

--- a/Sources/vo/Listen.swift
+++ b/Sources/vo/Listen.swift
@@ -23,8 +23,12 @@ func runListen(
 
     // Stream JSONL to disk as utterances finalize, so memory stays bounded for long
     // sessions. With --log we write straight to the user-specified path. Without it,
-    // we use a temp file and decide at shutdown whether to keep or discard.
-    let sessionLog = try SessionLog.open(explicitPath: log)
+    // we use a temp file and decide at shutdown whether to keep or discard. If the
+    // session can do neither (no --log AND no save prompt — e.g. piped JSONL run),
+    // skip the temp file entirely so we don't burn disk I/O writing bytes we know we
+    // are about to discard, and don't leave a large temp behind on a SIGKILL.
+    let canSaveLog = log != nil || (isTTY && canPromptForLog())
+    let sessionLog: SessionLog? = canSaveLog ? try SessionLog.open(explicitPath: log) : nil
 
     // If we throw out of this function before finalizeSession runs (e.g. the pipeline
     // errors mid-stream), make sure no temp file is left behind. In explicit mode we
@@ -33,9 +37,11 @@ func runListen(
     // since that is the one case where the temp file holding the captured data is what
     // we want the user to find.
     defer {
-        sessionLog.close()
-        if !sessionLog.isExplicit && !sessionLog.preservedForRecovery {
-            sessionLog.discard()
+        if let sessionLog {
+            sessionLog.close()
+            if !sessionLog.isExplicit && !sessionLog.preservedForRecovery {
+                sessionLog.discard()
+            }
         }
     }
 
@@ -97,21 +103,25 @@ func runListen(
 /// Close the session log, run save/discard logic, then print the exit summary.
 /// Called from both the SIGINT handler and the natural-completion path.
 private func finalizeSession(
-    sessionLog: SessionLog,
+    sessionLog: SessionLog?,
     isTTY: Bool,
     count: Int,
     duration: TimeInterval
 ) async {
-    // Gate the save prompt on isTTY (renderer mode), not just on canPromptForLog().
-    // Otherwise `vo --json` run from an interactive shell — where STDIN and STDOUT
-    // are both TTYs but the renderer is emitting machine-readable JSONL — would
-    // interleave the prompt text into the JSONL stream and corrupt it.
-    let status = resolveSessionLog(sessionLog: sessionLog, canPrompt: isTTY && canPromptForLog())
+    if let sessionLog {
+        // Gate the save prompt on isTTY (renderer mode), not just on canPromptForLog().
+        // Otherwise `vo --json` run from an interactive shell — where STDIN and STDOUT
+        // are both TTYs but the renderer is emitting machine-readable JSONL — would
+        // interleave the prompt text into the JSONL stream and corrupt it.
+        let status = resolveSessionLog(sessionLog: sessionLog, canPrompt: isTTY && canPromptForLog())
+        if isTTY {
+            if let status { print(status) }
+        } else if let status, sessionLog.isExplicit {
+            FileHandle.standardError.write(Data((status + "\n").utf8))
+        }
+    }
     if isTTY {
-        if let status { print(status) }
         printSummary(count: count, duration: duration)
-    } else if let status, sessionLog.isExplicit {
-        FileHandle.standardError.write(Data((status + "\n").utf8))
     }
 }
 

--- a/Sources/vo/Listen.swift
+++ b/Sources/vo/Listen.swift
@@ -9,7 +9,7 @@ func runListen(
     mic: Bool,
     speaker: Bool,
     voiceProcessing: Bool,
-    log: String?
+    transcript: String?
 ) async throws {
     guard mic || speaker else {
         throw ValidationError("Cannot disable both mic and speaker. Drop one of --no-mic / --no-speaker.")
@@ -22,13 +22,14 @@ func runListen(
     let isTTY = (mode == .tty)
 
     // Stream JSONL to disk as utterances finalize, so memory stays bounded for long
-    // sessions. With --log we write straight to the user-specified path. Without it,
-    // we use a temp file and decide at shutdown whether to keep or discard. If the
-    // session can do neither (no --log AND no save prompt — e.g. piped JSONL run),
-    // skip the temp file entirely so we don't burn disk I/O writing bytes we know we
-    // are about to discard, and don't leave a large temp behind on a SIGKILL.
-    let canSaveLog = log != nil || (isTTY && canPromptForLog())
-    let sessionLog: SessionLog? = canSaveLog ? try SessionLog.open(explicitPath: log) : nil
+    // sessions. With --transcript we write straight to the user-specified path.
+    // Without it, we use a temp file and decide at shutdown whether to keep or
+    // discard. If the session can do neither (no --transcript AND no save prompt —
+    // e.g. piped JSONL run), skip the temp file entirely so we don't burn disk I/O
+    // writing bytes we know we are about to discard, and don't leave a large temp
+    // behind on a SIGKILL.
+    let canSaveTranscript = transcript != nil || (isTTY && canPromptForLog())
+    let sessionLog: SessionLog? = canSaveTranscript ? try SessionLog.open(explicitPath: transcript) : nil
 
     // If we throw out of this function before finalizeSession runs (e.g. the pipeline
     // errors mid-stream), make sure no temp file is left behind. In explicit mode we

--- a/Sources/vo/Listen.swift
+++ b/Sources/vo/Listen.swift
@@ -98,7 +98,11 @@ private func finalizeSession(
     count: Int,
     duration: TimeInterval
 ) async {
-    let status = resolveSessionLog(sessionLog: sessionLog, canPrompt: canPromptForLog())
+    // Gate the save prompt on isTTY (renderer mode), not just on canPromptForLog().
+    // Otherwise `vo --json` run from an interactive shell — where STDIN and STDOUT
+    // are both TTYs but the renderer is emitting machine-readable JSONL — would
+    // interleave the prompt text into the JSONL stream and corrupt it.
+    let status = resolveSessionLog(sessionLog: sessionLog, canPrompt: isTTY && canPromptForLog())
     if isTTY {
         if let status { print(status) }
         printSummary(count: count, duration: duration)

--- a/Sources/vo/Pipeline.swift
+++ b/Sources/vo/Pipeline.swift
@@ -25,14 +25,24 @@ struct AsyncStopper: @unchecked Sendable {
 /// pulling mic/speaker frames while the user is deciding where to save the log.
 actor StopRegistry {
     private var stoppers: [AsyncStopper] = []
+    private var stopped: Bool = false
 
-    func register(_ stopper: AsyncStopper) {
+    /// Register a stopper. If `stopAll()` has already run, the stopper is invoked
+    /// immediately instead of being stored — otherwise a channel that finished
+    /// starting its audio source after SIGINT would leave that source running
+    /// while the save prompt blocks.
+    func register(_ stopper: AsyncStopper) async {
+        if stopped {
+            await stopper.action()
+            return
+        }
         stoppers.append(stopper)
     }
 
-    /// Run every registered stopper exactly once, in registration order. Safe to call
-    /// multiple times; the second call is a no-op.
+    /// Run every registered stopper exactly once, in registration order. Subsequent
+    /// `register` calls invoke the stopper inline; subsequent `stopAll` calls are no-ops.
     func stopAll() async {
+        stopped = true
         let pending = stoppers
         stoppers.removeAll()
         for s in pending { await s.action() }

--- a/Sources/vo/Pipeline.swift
+++ b/Sources/vo/Pipeline.swift
@@ -12,6 +12,33 @@ actor SeqCounter {
     }
 }
 
+/// Wrapper that lets us pass MicCapture/SpeakerCapture stop closures across actor
+/// boundaries without making the capture classes themselves Sendable. They are owned
+/// strictly by their channel Task and the registry is only ever invoked from a
+/// serialized actor context (or from `runChannel`'s own defer), so this is safe.
+struct AsyncStopper: @unchecked Sendable {
+    let action: () async -> Void
+}
+
+/// Holds per-channel "stop the audio source" closures so the SIGINT handler can
+/// stop capture before blocking on the save prompt. Without this the OS keeps
+/// pulling mic/speaker frames while the user is deciding where to save the log.
+actor StopRegistry {
+    private var stoppers: [AsyncStopper] = []
+
+    func register(_ stopper: AsyncStopper) {
+        stoppers.append(stopper)
+    }
+
+    /// Run every registered stopper exactly once, in registration order. Safe to call
+    /// multiple times; the second call is a no-op.
+    func stopAll() async {
+        let pending = stoppers
+        stoppers.removeAll()
+        for s in pending { await s.action() }
+    }
+}
+
 /// End-to-end pipeline that orchestrates one or more audio channels.
 ///
 /// For each enabled channel:
@@ -28,6 +55,9 @@ struct Pipeline {
     let enableMic: Bool
     let enableSpeaker: Bool
     let voiceProcessing: Bool  // apply AEC + NR + AGC on mic input
+    /// Lets callers (notably the SIGINT handler in Listen.swift) stop every active
+    /// audio source without having to wait for `run()` to unwind on its own.
+    let stops: StopRegistry = StopRegistry()
 
     func run() async throws {
         let counter = SeqCounter()
@@ -48,6 +78,12 @@ struct Pipeline {
 
         await renderer.handle(.eof)
         await renderer.flush()
+    }
+
+    /// Stop every registered audio source. Idempotent. Use this to halt the mic and
+    /// speaker captures before the SIGINT handler blocks on an interactive prompt.
+    func cancel() async {
+        await stops.stopAll()
     }
 
     // MARK: - Per-channel
@@ -89,6 +125,10 @@ struct Pipeline {
             audioStream = cap.stream
             stopper = { await cap.stop() }
         }
+
+        // Register the per-channel stopper so a SIGINT-triggered cancel() halts
+        // mic and speaker capture before any save prompt blocks the main task.
+        await stops.register(AsyncStopper(action: stopper))
 
         // Translation worker for this channel (only when targetLocale is set).
         // TranslationSession is non-Sendable so we create it inside the Task closure.

--- a/Sources/vo/Renderer.swift
+++ b/Sources/vo/Renderer.swift
@@ -146,9 +146,13 @@ actor StreamRenderer: Renderer {
     }
 
     private func emitSourceOnly(channel: AudioChannel, seq: Int, source: String, timing: ChunkTiming) {
-        var obj: [String: Any] = jsonlBase(seq: seq, channel: channel, timing: timing)
-        obj["src"] = ["lang": sourceLang, "text": source]
-        let jsonl = jsonString(obj)
+        // Skip the JSONSerialization unless someone is going to consume it. In TTY
+        // mode with no transcript sink (e.g. `vo < /dev/null` where stdout is a TTY
+        // but stdin isn't, so SessionLog is never opened) the serialized bytes
+        // would just be thrown away.
+        let jsonl: String? = (mode == .jsonl || logSink != nil)
+            ? buildJSONL(seq: seq, channel: channel, source: source, target: nil, timing: timing, includeTarget: false)
+            : nil
 
         if let jsonl { logSink?.append(jsonl) }
 
@@ -161,13 +165,9 @@ actor StreamRenderer: Renderer {
     }
 
     private func emitCommittedPair(pair: Pair, target: String?) {
-        var obj: [String: Any] = jsonlBase(seq: pair.seq, channel: pair.channel, timing: pair.timing)
-        obj["src"] = ["lang": sourceLang, "text": pair.source]
-        if translationEnabled {
-            obj["dst"] = target.map { ["lang": targetLang, "text": $0] }
-                ?? ["lang": targetLang, "text": NSNull()]
-        }
-        let jsonl = jsonString(obj)
+        let jsonl: String? = (mode == .jsonl || logSink != nil)
+            ? buildJSONL(seq: pair.seq, channel: pair.channel, source: pair.source, target: target, timing: pair.timing, includeTarget: translationEnabled)
+            : nil
 
         if let jsonl { logSink?.append(jsonl) }
 
@@ -182,6 +182,23 @@ actor StreamRenderer: Renderer {
         case .jsonl:
             if let jsonl { writeLine(jsonl) }
         }
+    }
+
+    private func buildJSONL(
+        seq: Int,
+        channel: AudioChannel,
+        source: String,
+        target: String?,
+        timing: ChunkTiming,
+        includeTarget: Bool
+    ) -> String? {
+        var obj: [String: Any] = jsonlBase(seq: seq, channel: channel, timing: timing)
+        obj["src"] = ["lang": sourceLang, "text": source]
+        if includeTarget {
+            obj["dst"] = target.map { ["lang": targetLang, "text": $0] }
+                ?? ["lang": targetLang, "text": NSNull()]
+        }
+        return jsonString(obj)
     }
 
     // MARK: - TTY formatting helpers

--- a/Sources/vo/Renderer.swift
+++ b/Sources/vo/Renderer.swift
@@ -51,11 +51,13 @@ actor StreamRenderer: Renderer {
     private let sourceLang: String
     private let targetLang: String
     private let translationEnabled: Bool
+    private let logSink: SessionLog?
 
     private var commitQueue: [Pair] = []
     private var volatileTexts: [AudioChannel: String] = [:]
     private var liveRegionLines: Int = 0   // how many lines we currently own at the bottom
     private var finalizedCount: Int = 0    // total utterances finalized (for exit summary)
+    private var isShuttingDown: Bool = false
 
     /// Total utterances finalized so far (across all channels).
     var utteranceCount: Int { finalizedCount }
@@ -65,15 +67,24 @@ actor StreamRenderer: Renderer {
         case jsonl
     }
 
-    init(mode: Mode, sourceLang: String, targetLang: String, translationEnabled: Bool = true, out: FileHandle = .standardOutput) {
+    init(
+        mode: Mode,
+        sourceLang: String,
+        targetLang: String,
+        translationEnabled: Bool = true,
+        out: FileHandle = .standardOutput,
+        logSink: SessionLog? = nil
+    ) {
         self.mode = mode
         self.out = out
         self.sourceLang = sourceLang
         self.targetLang = targetLang
         self.translationEnabled = translationEnabled
+        self.logSink = logSink
     }
 
     func handle(_ event: RenderEvent) async {
+        if isShuttingDown { return }
         switch event {
         case .volatile(let channel, let text):
             volatileTexts[channel] = text
@@ -105,6 +116,9 @@ actor StreamRenderer: Renderer {
             if mode == .tty {
                 clearLiveRegion()
             }
+            // After eof, ignore any straggler events so audio threads can't redraw
+            // over the exit prompt/summary that follows.
+            isShuttingDown = true
         }
     }
 
@@ -132,17 +146,31 @@ actor StreamRenderer: Renderer {
     }
 
     private func emitSourceOnly(channel: AudioChannel, seq: Int, source: String, timing: ChunkTiming) {
+        var obj: [String: Any] = jsonlBase(seq: seq, channel: channel, timing: timing)
+        obj["src"] = ["lang": sourceLang, "text": source]
+        let jsonl = jsonString(obj)
+
+        if let jsonl { logSink?.append(jsonl) }
+
         switch mode {
         case .tty:
             writeLine("\(ttyTimestamp(timing.timestamp))  \(ttyChannel(channel))  \(source)")
         case .jsonl:
-            var obj: [String: Any] = jsonlBase(seq: seq, channel: channel, timing: timing)
-            obj["src"] = ["lang": sourceLang, "text": source]
-            writeJSONLine(obj)
+            if let jsonl { writeLine(jsonl) }
         }
     }
 
     private func emitCommittedPair(pair: Pair, target: String?) {
+        var obj: [String: Any] = jsonlBase(seq: pair.seq, channel: pair.channel, timing: pair.timing)
+        obj["src"] = ["lang": sourceLang, "text": pair.source]
+        if translationEnabled {
+            obj["dst"] = target.map { ["lang": targetLang, "text": $0] }
+                ?? ["lang": targetLang, "text": NSNull()]
+        }
+        let jsonl = jsonString(obj)
+
+        if let jsonl { logSink?.append(jsonl) }
+
         switch mode {
         case .tty:
             writeLine("\(ttyTimestamp(pair.timing.timestamp))  \(ttyChannel(pair.channel))  \(pair.source)")
@@ -151,13 +179,8 @@ actor StreamRenderer: Renderer {
             } else {
                 writeLine("\(Self.sourceColumnPad)\u{001B}[38;5;240m(no translation)\u{001B}[0m")
             }
-
         case .jsonl:
-            var obj: [String: Any] = jsonlBase(seq: pair.seq, channel: pair.channel, timing: pair.timing)
-            obj["src"] = ["lang": sourceLang, "text": pair.source]
-            obj["dst"] = target.map { ["lang": targetLang, "text": $0] }
-                ?? ["lang": targetLang, "text": NSNull()]
-            writeJSONLine(obj)
+            if let jsonl { writeLine(jsonl) }
         }
     }
 
@@ -194,11 +217,9 @@ actor StreamRenderer: Renderer {
         return obj
     }
 
-    private func writeJSONLine(_ obj: [String: Any]) {
-        if let data = try? JSONSerialization.data(withJSONObject: obj),
-           let line = String(data: data, encoding: .utf8) {
-            writeLine(line)
-        }
+    private func jsonString(_ obj: [String: Any]) -> String? {
+        guard let data = try? JSONSerialization.data(withJSONObject: obj) else { return nil }
+        return String(data: data, encoding: .utf8)
     }
 
     // ISO8601DateFormatter's `string(from:)` is documented as thread-safe.

--- a/Sources/vo/SessionLog.swift
+++ b/Sources/vo/SessionLog.swift
@@ -84,9 +84,13 @@ final class SessionLog: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         guard !isClosed else { return }
-        if let data = (line + "\n").data(using: .utf8) {
-            try? fileHandle.write(contentsOf: data)
+        guard let data = (line + "\n").data(using: .utf8) else { return }
+        do {
+            try fileHandle.write(contentsOf: data)
             hasContent = true
+        } catch {
+            // Swallow but do not flip hasContent so the save/preserve path won't
+            // be triggered for a file that never received any bytes.
         }
     }
 

--- a/Sources/vo/SessionLog.swift
+++ b/Sources/vo/SessionLog.swift
@@ -128,14 +128,18 @@ final class SessionLog: @unchecked Sendable {
         // Belt and suspenders: the prompt layer already rejects directory targets, but
         // refuse here too so a future caller can't accidentally `removeItem` a whole
         // directory tree just because they reused move() with a different prompt.
-        var isDir: ObjCBool = false
-        if FileManager.default.fileExists(atPath: resolvedDst, isDirectory: &isDir), isDir.boolValue {
+        if isDirectory(resolvedDst) {
             throw SessionLogError.destinationIsDirectory(path: resolvedDst)
         }
 
         let dst = URL(fileURLWithPath: resolvedDst)
         let src = URL(fileURLWithPath: path)
-        try? FileManager.default.removeItem(at: dst)
+        // Propagate removeItem errors instead of letting moveItem surface them
+        // later as a confusing "file exists" — a locked or permission-denied
+        // destination should fail with its actual reason and preserve the temp.
+        if FileManager.default.fileExists(atPath: resolvedDst) {
+            try FileManager.default.removeItem(at: dst)
+        }
         try FileManager.default.moveItem(at: src, to: dst)
     }
 

--- a/Sources/vo/SessionLog.swift
+++ b/Sources/vo/SessionLog.swift
@@ -53,6 +53,10 @@ final class SessionLog: @unchecked Sendable {
             }
             FileManager.default.createFile(atPath: resolved, contents: nil)
             let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: resolved))
+            // createFile already truncates an existing file to 0 bytes, but make the
+            // overwrite-semantics explicit at the handle level so no future reader has
+            // to reason about NSFileManager's documented behavior.
+            try? handle.truncate(atOffset: 0)
             return SessionLog(
                 path: resolved,
                 suggestedPath: resolved,
@@ -66,6 +70,7 @@ final class SessionLog: @unchecked Sendable {
         let tempPath = (tmpDir as NSString).appendingPathComponent("vo-\(stamp)-\(pid).jsonl")
         FileManager.default.createFile(atPath: tempPath, contents: nil)
         let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: tempPath))
+        try? handle.truncate(atOffset: 0)
         return SessionLog(
             path: tempPath,
             suggestedPath: "./vo-\(stamp).jsonl",

--- a/Sources/vo/SessionLog.swift
+++ b/Sources/vo/SessionLog.swift
@@ -47,11 +47,21 @@ final class SessionLog: @unchecked Sendable {
 
         if let explicitPath {
             let resolved = (explicitPath as NSString).expandingTildeInPath
+            // Treat each failure mode as a distinct early-exit path so the message
+            // the user sees matches what actually went wrong — previously a directory
+            // target produced two prints ("is a directory; ..." plus "Aborted: ...
+            // already exists.") that contradicted each other.
+            if isDirectory(resolved) {
+                print("Cannot write transcript to \(resolved): path is a directory.")
+                Foundation.exit(0)
+            }
             if !confirmOverwriteIfNeeded(path: resolved) {
                 print("Aborted: \(resolved) already exists.")
                 Foundation.exit(0)
             }
-            FileManager.default.createFile(atPath: resolved, contents: nil)
+            guard FileManager.default.createFile(atPath: resolved, contents: nil) else {
+                throw SessionLogError.createFailed(path: resolved)
+            }
             let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: resolved))
             // createFile already truncates an existing file to 0 bytes, but make the
             // overwrite-semantics explicit at the handle level so no future reader has
@@ -68,7 +78,9 @@ final class SessionLog: @unchecked Sendable {
         let tmpDir = NSTemporaryDirectory()
         let pid = ProcessInfo.processInfo.processIdentifier
         let tempPath = (tmpDir as NSString).appendingPathComponent("vo-\(stamp)-\(pid).jsonl")
-        FileManager.default.createFile(atPath: tempPath, contents: nil)
+        guard FileManager.default.createFile(atPath: tempPath, contents: nil) else {
+            throw SessionLogError.createFailed(path: tempPath)
+        }
         let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: tempPath))
         try? handle.truncate(atOffset: 0)
         return SessionLog(
@@ -144,6 +156,14 @@ final class SessionLog: @unchecked Sendable {
     }
 }
 
+/// `true` if `path` exists and is a directory. Used to refuse directory targets at the
+/// save prompt and at explicit-mode startup with a clear message instead of letting
+/// the failure surface as a confusing FileHandle / move() error later on.
+private func isDirectory(_ path: String) -> Bool {
+    var isDir: ObjCBool = false
+    return FileManager.default.fileExists(atPath: path, isDirectory: &isDir) && isDir.boolValue
+}
+
 /// Decide what to do with the session log on exit and execute it.
 /// Returns a short human-readable status message (or nil for silent).
 func resolveSessionLog(sessionLog: SessionLog, canPrompt: Bool) -> String? {
@@ -179,7 +199,12 @@ func resolveSessionLog(sessionLog: SessionLog, canPrompt: Bool) -> String? {
             return nil
         }
 
-        if !confirmOverwriteIfNeeded(path: (target as NSString).expandingTildeInPath) {
+        let resolvedTarget = (target as NSString).expandingTildeInPath
+        if isDirectory(resolvedTarget) {
+            print("\(resolvedTarget) is a directory; choose a file path instead.")
+            continue
+        }
+        if !confirmOverwriteIfNeeded(path: resolvedTarget) {
             continue
         }
 
@@ -199,15 +224,11 @@ func resolveSessionLog(sessionLog: SessionLog, canPrompt: Bool) -> String? {
 /// Prompt for overwrite confirmation if `path` already exists. Returns `true` to proceed,
 /// `false` to abort. In non-TTY contexts we proceed silently (matching existing semantics
 /// of file creation), since there is no human to ask.
+///
+/// Callers must check `isDirectory(_:)` first — this helper only handles the file-exists
+/// case and the dir branch was removed to keep failure messages single-purpose.
 private func confirmOverwriteIfNeeded(path: String) -> Bool {
-    var isDir: ObjCBool = false
-    guard FileManager.default.fileExists(atPath: path, isDirectory: &isDir) else { return true }
-    // Refuse directory targets up front. "Overwrite a directory?" is the wrong
-    // question — saying yes here would let move() delete the whole tree.
-    if isDir.boolValue {
-        print("\(path) is a directory; choose a file path instead.")
-        return false
-    }
+    guard FileManager.default.fileExists(atPath: path) else { return true }
     guard canPromptForLog() else { return true }
     print("\(path) already exists. Overwrite? [y/N]: ", terminator: "")
     // stdout is line-buffered on a TTY, so a no-newline prompt would otherwise
@@ -220,11 +241,14 @@ private func confirmOverwriteIfNeeded(path: String) -> Bool {
 
 enum SessionLogError: Error, CustomStringConvertible {
     case destinationIsDirectory(path: String)
+    case createFailed(path: String)
 
     var description: String {
         switch self {
         case .destinationIsDirectory(let path):
-            return "Cannot write log to \(path): path is a directory."
+            return "Cannot write transcript to \(path): path is a directory."
+        case .createFailed(let path):
+            return "Could not create transcript file at \(path) (check that the parent directory exists and is writable)."
         }
     }
 }

--- a/Sources/vo/SessionLog.swift
+++ b/Sources/vo/SessionLog.swift
@@ -19,6 +19,11 @@ final class SessionLog: @unchecked Sendable {
     /// `true` when `--log` was given. Explicit mode skips the prompt and bypasses the temp
     /// machinery entirely (no temp file ever exists).
     let isExplicit: Bool
+    /// Set when `resolveSessionLog` has intentionally kept the temp file in place (e.g. the
+    /// chosen move target failed and we surfaced its temp path to the user). The cleanup
+    /// `defer` in `Listen.swift` checks this so the safety-net discard does not destroy the
+    /// very recovery file we just promised to preserve.
+    fileprivate(set) var preservedForRecovery: Bool = false
 
     private let fileHandle: FileHandle
     private var hasContent: Bool = false
@@ -158,7 +163,9 @@ func resolveSessionLog(sessionLog: SessionLog, canPrompt: Bool) -> String? {
         return "Saved log: \(target)"
     } catch {
         // Move failed (bad path, permission, etc.). Keep the temp file so the user
-        // can recover it manually, and report where it is.
+        // can recover it manually, and mark it so the Listen.swift safety-net defer
+        // will not discard the file we just told the user we preserved.
+        sessionLog.preservedForRecovery = true
         return "Failed to save log to \(target): \(error.localizedDescription)\n  Log preserved at: \(sessionLog.path)"
     }
 }

--- a/Sources/vo/SessionLog.swift
+++ b/Sources/vo/SessionLog.swift
@@ -6,7 +6,7 @@ import Darwin
 /// Streaming JSONL log file used to persist a session without buffering events in memory.
 ///
 /// Two modes:
-///   - **Explicit**: `--log <path>` was given. We open that path directly and stream into it.
+///   - **Explicit**: `--transcript <path>` was given. We open that path directly and stream into it.
 ///     No temp file, no rename, no discard.
 ///   - **Temp**: opens a file under TMPDIR. At shutdown, the temp file is either moved to a
 ///     user-chosen path (via prompt) or removed.
@@ -16,8 +16,8 @@ final class SessionLog: @unchecked Sendable {
     let path: String
     /// Path used as the default in the interactive prompt. Same as `path` for explicit mode.
     let suggestedPath: String
-    /// `true` when `--log` was given. Explicit mode skips the prompt and bypasses the temp
-    /// machinery entirely (no temp file ever exists).
+    /// `true` when `--transcript` was given. Explicit mode skips the prompt and bypasses the
+    /// temp machinery entirely (no temp file ever exists).
     let isExplicit: Bool
     /// Set when `resolveSessionLog` has intentionally kept the temp file in place (e.g. the
     /// chosen move target failed and we surfaced its temp path to the user). The cleanup
@@ -155,9 +155,9 @@ func resolveSessionLog(sessionLog: SessionLog, canPrompt: Bool) -> String? {
         if sessionLog.isEmpty {
             // No utterances captured. Leave an empty file rather than silently delete
             // something the user explicitly named.
-            return "Saved log: \(sessionLog.path) (no utterances)"
+            return "Saved transcript: \(sessionLog.path) (no utterances)"
         }
-        return "Saved log: \(sessionLog.path)"
+        return "Saved transcript: \(sessionLog.path)"
     }
 
     // Temp mode: nothing captured, just clean up.
@@ -185,13 +185,13 @@ func resolveSessionLog(sessionLog: SessionLog, canPrompt: Bool) -> String? {
 
         do {
             try sessionLog.move(to: target)
-            return "Saved log: \(target)"
+            return "Saved transcript: \(target)"
         } catch {
             // Move failed (bad path, permission, etc.). Keep the temp file so the user
             // can recover it manually, and mark it so the Listen.swift safety-net defer
             // will not discard the file we just told the user we preserved.
             sessionLog.preservedForRecovery = true
-            return "Failed to save log to \(target): \(error.localizedDescription)\n  Log preserved at: \(sessionLog.path)"
+            return "Failed to save transcript to \(target): \(error.localizedDescription)\n  Transcript preserved at: \(sessionLog.path)"
         }
     }
 }
@@ -232,7 +232,7 @@ enum SessionLogError: Error, CustomStringConvertible {
 /// Interactive prompt. Returns the chosen path, or nil if the user declined.
 private func promptForLogPath(defaultPath: String) -> String? {
     print("")
-    print("Save log to \(defaultPath)? [Y/n/<path>]: ", terminator: "")
+    print("Save transcript to \(defaultPath)? [Y/n/<path>]: ", terminator: "")
     fflush(stdout)
     guard let line = readLine() else { return nil }
     let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/vo/SessionLog.swift
+++ b/Sources/vo/SessionLog.swift
@@ -148,25 +148,33 @@ func resolveSessionLog(sessionLog: SessionLog, canPrompt: Bool) -> String? {
         return nil
     }
 
-    guard canPrompt, let target = promptForLogPath(defaultPath: sessionLog.suggestedPath) else {
+    guard canPrompt else {
         sessionLog.discard()
         return nil
     }
 
-    if !confirmOverwriteIfNeeded(path: (target as NSString).expandingTildeInPath) {
-        sessionLog.discard()
-        return "Discarded log (declined overwrite of \(target))"
-    }
+    // Loop so that declining an overwrite returns the user to the save prompt
+    // for a different path rather than throwing the captured session away.
+    while true {
+        guard let target = promptForLogPath(defaultPath: sessionLog.suggestedPath) else {
+            sessionLog.discard()
+            return nil
+        }
 
-    do {
-        try sessionLog.move(to: target)
-        return "Saved log: \(target)"
-    } catch {
-        // Move failed (bad path, permission, etc.). Keep the temp file so the user
-        // can recover it manually, and mark it so the Listen.swift safety-net defer
-        // will not discard the file we just told the user we preserved.
-        sessionLog.preservedForRecovery = true
-        return "Failed to save log to \(target): \(error.localizedDescription)\n  Log preserved at: \(sessionLog.path)"
+        if !confirmOverwriteIfNeeded(path: (target as NSString).expandingTildeInPath) {
+            continue
+        }
+
+        do {
+            try sessionLog.move(to: target)
+            return "Saved log: \(target)"
+        } catch {
+            // Move failed (bad path, permission, etc.). Keep the temp file so the user
+            // can recover it manually, and mark it so the Listen.swift safety-net defer
+            // will not discard the file we just told the user we preserved.
+            sessionLog.preservedForRecovery = true
+            return "Failed to save log to \(target): \(error.localizedDescription)\n  Log preserved at: \(sessionLog.path)"
+        }
     }
 }
 

--- a/Sources/vo/SessionLog.swift
+++ b/Sources/vo/SessionLog.swift
@@ -194,6 +194,9 @@ private func confirmOverwriteIfNeeded(path: String) -> Bool {
     guard FileManager.default.fileExists(atPath: path) else { return true }
     guard canPromptForLog() else { return true }
     print("\(path) already exists. Overwrite? [y/N]: ", terminator: "")
+    // stdout is line-buffered on a TTY, so a no-newline prompt would otherwise
+    // sit in the buffer until readLine returns — the user would never see it.
+    fflush(stdout)
     guard let line = readLine() else { return false }
     let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     return trimmed == "y" || trimmed == "yes"
@@ -203,6 +206,7 @@ private func confirmOverwriteIfNeeded(path: String) -> Bool {
 private func promptForLogPath(defaultPath: String) -> String? {
     print("")
     print("Save log to \(defaultPath)? [Y/n/<path>]: ", terminator: "")
+    fflush(stdout)
     guard let line = readLine() else { return nil }
     let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
     if trimmed.isEmpty { return defaultPath }

--- a/Sources/vo/SessionLog.swift
+++ b/Sources/vo/SessionLog.swift
@@ -168,6 +168,17 @@ private func isDirectory(_ path: String) -> Bool {
     return FileManager.default.fileExists(atPath: path, isDirectory: &isDir) && isDir.boolValue
 }
 
+/// Render an `Error` for the user. Prefer the type's own `CustomStringConvertible`
+/// description so our `SessionLogError` cases show their action-oriented message
+/// ("path is a directory.") instead of NSError's generic
+/// "The operation couldn't be completed." that `localizedDescription` would produce.
+private func describe(_ error: Error) -> String {
+    if let custom = error as? CustomStringConvertible {
+        return custom.description
+    }
+    return error.localizedDescription
+}
+
 /// Decide what to do with the session log on exit and execute it.
 /// Returns a short human-readable status message (or nil for silent).
 func resolveSessionLog(sessionLog: SessionLog, canPrompt: Bool) -> String? {
@@ -220,7 +231,7 @@ func resolveSessionLog(sessionLog: SessionLog, canPrompt: Bool) -> String? {
             // can recover it manually, and mark it so the Listen.swift safety-net defer
             // will not discard the file we just told the user we preserved.
             sessionLog.preservedForRecovery = true
-            return "Failed to save transcript to \(target): \(error.localizedDescription)\n  Transcript preserved at: \(sessionLog.path)"
+            return "Failed to save transcript to \(target): \(describe(error))\n  Transcript preserved at: \(sessionLog.path)"
         }
     }
 }

--- a/Sources/vo/SessionLog.swift
+++ b/Sources/vo/SessionLog.swift
@@ -1,0 +1,195 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
+
+/// Streaming JSONL log file used to persist a session without buffering events in memory.
+///
+/// Two modes:
+///   - **Explicit**: `--log <path>` was given. We open that path directly and stream into it.
+///     No temp file, no rename, no discard.
+///   - **Temp**: opens a file under TMPDIR. At shutdown, the temp file is either moved to a
+///     user-chosen path (via prompt) or removed.
+final class SessionLog: @unchecked Sendable {
+    /// Current path of the open file. For temp mode this is the temp location; for explicit
+    /// mode it is the user-supplied destination.
+    let path: String
+    /// Path used as the default in the interactive prompt. Same as `path` for explicit mode.
+    let suggestedPath: String
+    /// `true` when `--log` was given. Explicit mode skips the prompt and bypasses the temp
+    /// machinery entirely (no temp file ever exists).
+    let isExplicit: Bool
+
+    private let fileHandle: FileHandle
+    private var hasContent: Bool = false
+    private var isClosed: Bool = false
+    private let lock = NSLock()
+
+    private init(path: String, suggestedPath: String, isExplicit: Bool, fileHandle: FileHandle) {
+        self.path = path
+        self.suggestedPath = suggestedPath
+        self.isExplicit = isExplicit
+        self.fileHandle = fileHandle
+    }
+
+    /// Open the session log. If `explicitPath` is non-nil we write directly there; otherwise
+    /// a temp file is created and cleaned up by `resolveSessionLog` on exit.
+    ///
+    /// If `explicitPath` already exists and the user (in TTY mode) declines to overwrite,
+    /// this prints a message and calls `Foundation.exit(0)` since there's nothing left to do.
+    static func open(explicitPath: String?) throws -> SessionLog {
+        let stamp = filenameStamp(Date())
+
+        if let explicitPath {
+            let resolved = (explicitPath as NSString).expandingTildeInPath
+            if !confirmOverwriteIfNeeded(path: resolved) {
+                print("Aborted: \(resolved) already exists.")
+                Foundation.exit(0)
+            }
+            FileManager.default.createFile(atPath: resolved, contents: nil)
+            let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: resolved))
+            return SessionLog(
+                path: resolved,
+                suggestedPath: resolved,
+                isExplicit: true,
+                fileHandle: handle
+            )
+        }
+
+        let tmpDir = NSTemporaryDirectory()
+        let pid = ProcessInfo.processInfo.processIdentifier
+        let tempPath = (tmpDir as NSString).appendingPathComponent("vo-\(stamp)-\(pid).jsonl")
+        FileManager.default.createFile(atPath: tempPath, contents: nil)
+        let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: tempPath))
+        return SessionLog(
+            path: tempPath,
+            suggestedPath: "./vo-\(stamp).jsonl",
+            isExplicit: false,
+            fileHandle: handle
+        )
+    }
+
+    /// Append one JSONL line (we add the trailing newline).
+    func append(_ line: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !isClosed else { return }
+        if let data = (line + "\n").data(using: .utf8) {
+            try? fileHandle.write(contentsOf: data)
+            hasContent = true
+        }
+    }
+
+    func close() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !isClosed else { return }
+        try? fileHandle.synchronize()
+        try? fileHandle.close()
+        isClosed = true
+    }
+
+    var isEmpty: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return !hasContent
+    }
+
+    /// Move the temp file to `destination`. Only valid in temp mode.
+    func move(to destination: String) throws {
+        precondition(!isExplicit, "move() is for temp mode only")
+        let resolvedDst = (destination as NSString).expandingTildeInPath
+        let dst = URL(fileURLWithPath: resolvedDst)
+        let src = URL(fileURLWithPath: path)
+        try? FileManager.default.removeItem(at: dst)
+        try FileManager.default.moveItem(at: src, to: dst)
+    }
+
+    /// Delete the underlying file. Used in temp mode when the user declined to save, and
+    /// also belt-and-suspenders to make sure no temp file is ever left behind.
+    func discard() {
+        try? FileManager.default.removeItem(atPath: path)
+    }
+
+    // MARK: - Helpers
+
+    private static func filenameStamp(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd-HHmmss"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = .current
+        return f.string(from: date)
+    }
+}
+
+/// Decide what to do with the session log on exit and execute it.
+/// Returns a short human-readable status message (or nil for silent).
+func resolveSessionLog(sessionLog: SessionLog, canPrompt: Bool) -> String? {
+    sessionLog.close()
+
+    // Explicit mode: file was already written to the user's path. Nothing to move,
+    // nothing to discard.
+    if sessionLog.isExplicit {
+        if sessionLog.isEmpty {
+            // No utterances captured. Leave an empty file rather than silently delete
+            // something the user explicitly named.
+            return "Saved log: \(sessionLog.path) (no utterances)"
+        }
+        return "Saved log: \(sessionLog.path)"
+    }
+
+    // Temp mode: nothing captured, just clean up.
+    if sessionLog.isEmpty {
+        sessionLog.discard()
+        return nil
+    }
+
+    guard canPrompt, let target = promptForLogPath(defaultPath: sessionLog.suggestedPath) else {
+        sessionLog.discard()
+        return nil
+    }
+
+    if !confirmOverwriteIfNeeded(path: (target as NSString).expandingTildeInPath) {
+        sessionLog.discard()
+        return "Discarded log (declined overwrite of \(target))"
+    }
+
+    do {
+        try sessionLog.move(to: target)
+        return "Saved log: \(target)"
+    } catch {
+        // Move failed (bad path, permission, etc.). Keep the temp file so the user
+        // can recover it manually, and report where it is.
+        return "Failed to save log to \(target): \(error.localizedDescription)\n  Log preserved at: \(sessionLog.path)"
+    }
+}
+
+/// Prompt for overwrite confirmation if `path` already exists. Returns `true` to proceed,
+/// `false` to abort. In non-TTY contexts we proceed silently (matching existing semantics
+/// of file creation), since there is no human to ask.
+private func confirmOverwriteIfNeeded(path: String) -> Bool {
+    guard FileManager.default.fileExists(atPath: path) else { return true }
+    guard canPromptForLog() else { return true }
+    print("\(path) already exists. Overwrite? [y/N]: ", terminator: "")
+    guard let line = readLine() else { return false }
+    let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    return trimmed == "y" || trimmed == "yes"
+}
+
+/// Interactive prompt. Returns the chosen path, or nil if the user declined.
+private func promptForLogPath(defaultPath: String) -> String? {
+    print("")
+    print("Save log to \(defaultPath)? [Y/n/<path>]: ", terminator: "")
+    guard let line = readLine() else { return nil }
+    let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty { return defaultPath }
+    switch trimmed.lowercased() {
+    case "y", "yes": return defaultPath
+    case "n", "no":  return nil
+    default:         return trimmed
+    }
+}
+
+/// `true` when both STDIN and STDOUT are attached to a terminal (so we can both prompt and read).
+func canPromptForLog() -> Bool {
+    return isatty(fileno(stdin)) != 0 && isatty(fileno(stdout)) != 0
+}

--- a/Sources/vo/SessionLog.swift
+++ b/Sources/vo/SessionLog.swift
@@ -112,6 +112,15 @@ final class SessionLog: @unchecked Sendable {
     func move(to destination: String) throws {
         precondition(!isExplicit, "move() is for temp mode only")
         let resolvedDst = (destination as NSString).expandingTildeInPath
+
+        // Belt and suspenders: the prompt layer already rejects directory targets, but
+        // refuse here too so a future caller can't accidentally `removeItem` a whole
+        // directory tree just because they reused move() with a different prompt.
+        var isDir: ObjCBool = false
+        if FileManager.default.fileExists(atPath: resolvedDst, isDirectory: &isDir), isDir.boolValue {
+            throw SessionLogError.destinationIsDirectory(path: resolvedDst)
+        }
+
         let dst = URL(fileURLWithPath: resolvedDst)
         let src = URL(fileURLWithPath: path)
         try? FileManager.default.removeItem(at: dst)
@@ -191,7 +200,14 @@ func resolveSessionLog(sessionLog: SessionLog, canPrompt: Bool) -> String? {
 /// `false` to abort. In non-TTY contexts we proceed silently (matching existing semantics
 /// of file creation), since there is no human to ask.
 private func confirmOverwriteIfNeeded(path: String) -> Bool {
-    guard FileManager.default.fileExists(atPath: path) else { return true }
+    var isDir: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: path, isDirectory: &isDir) else { return true }
+    // Refuse directory targets up front. "Overwrite a directory?" is the wrong
+    // question — saying yes here would let move() delete the whole tree.
+    if isDir.boolValue {
+        print("\(path) is a directory; choose a file path instead.")
+        return false
+    }
     guard canPromptForLog() else { return true }
     print("\(path) already exists. Overwrite? [y/N]: ", terminator: "")
     // stdout is line-buffered on a TTY, so a no-newline prompt would otherwise
@@ -200,6 +216,17 @@ private func confirmOverwriteIfNeeded(path: String) -> Bool {
     guard let line = readLine() else { return false }
     let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     return trimmed == "y" || trimmed == "yes"
+}
+
+enum SessionLogError: Error, CustomStringConvertible {
+    case destinationIsDirectory(path: String)
+
+    var description: String {
+        switch self {
+        case .destinationIsDirectory(let path):
+            return "Cannot write log to \(path): path is a directory."
+        }
+    }
 }
 
 /// Interactive prompt. Returns the chosen path, or nil if the user declined.

--- a/Sources/vo/Vo.swift
+++ b/Sources/vo/Vo.swift
@@ -36,7 +36,7 @@ struct Vo: AsyncParsableCommand {
     @Flag(name: .long, help: "Force machine-readable JSON output. Without this, auto-detects based on whether STDOUT is a TTY.")
     var json: Bool = false
 
-    @Option(name: .long, help: "Save finalized chunks as JSONL to this path on exit. Skips the interactive save prompt.")
+    @Option(name: .long, help: "Stream finalized chunks as JSONL to this path (written incrementally so you can `tail -f` it; memory stays bounded for long sessions). Skips the interactive save prompt.")
     var log: String?
 
     // MARK: - Run

--- a/Sources/vo/Vo.swift
+++ b/Sources/vo/Vo.swift
@@ -36,6 +36,9 @@ struct Vo: AsyncParsableCommand {
     @Flag(name: .long, help: "Force machine-readable JSON output. Without this, auto-detects based on whether STDOUT is a TTY.")
     var json: Bool = false
 
+    @Option(name: .long, help: "Save finalized chunks as JSONL to this path on exit. Skips the interactive save prompt.")
+    var log: String?
+
     // MARK: - Run
 
     func run() async throws {
@@ -50,7 +53,8 @@ struct Vo: AsyncParsableCommand {
             json: json,
             mic: !noMic,
             speaker: !noSpeaker,
-            voiceProcessing: voiceProcessing
+            voiceProcessing: voiceProcessing,
+            log: log
         )
     }
 }

--- a/Sources/vo/Vo.swift
+++ b/Sources/vo/Vo.swift
@@ -37,7 +37,7 @@ struct Vo: AsyncParsableCommand {
     var json: Bool = false
 
     @Option(name: .long, help: "Stream finalized chunks as JSONL to this path (written incrementally so you can `tail -f` it; memory stays bounded for long sessions). Skips the interactive save prompt.")
-    var log: String?
+    var transcript: String?
 
     // MARK: - Run
 
@@ -54,7 +54,7 @@ struct Vo: AsyncParsableCommand {
             mic: !noMic,
             speaker: !noSpeaker,
             voiceProcessing: voiceProcessing,
-            log: log
+            transcript: transcript
         )
     }
 }


### PR DESCRIPTION
## Summary

Add `--transcript <path>` so a session's finalized chunks are persisted as JSONL without buffering everything in memory. Without `--transcript`, vo still streams to a temp file and asks the user at Ctrl-C whether to keep it. With `--transcript`, the file is opened up front and written to incrementally — no prompt, no temp.

The original motivation was running vo for 100+ minutes: the previous design (no on-disk transcript) lost data on Ctrl-C, and a naive in-memory buffer would have ballooned over time.

## Changes

- New `Sources/vo/SessionLog.swift` — streaming JSONL transcript with two modes:
  - **Explicit** (`--transcript <path>`): opens `<path>` directly. If the path exists in TTY mode, prompts `Overwrite? [y/N]` before truncating. Directory targets are refused.
  - **Temp**: opens a file under `TMPDIR`. At Ctrl-C / EOF the user is asked `Save transcript to ./vo-<stamp>.jsonl? [Y/n/<path>]`. A custom path that already exists triggers the same overwrite prompt; declining the overwrite loops back to the save prompt rather than discarding the captured session. Move-target failure preserves the temp file for recovery.
- `Renderer` gains an optional `logSink: SessionLog?` and writes a JSONL line to it for every finalized chunk, regardless of TTY/JSONL output mode. The JSONL serialization happens once per chunk; the result is used for both stdout (in JSONL mode) and the transcript sink.
- `Renderer` flips an `isShuttingDown` flag inside the `.eof` case so any straggler audio events that arrive after the live region has been cleared can't redraw on top of the exit prompt or summary.
- `Pipeline` exposes a `cancel()` that halts every registered audio source. The SIGINT handler calls it before `finalizeSession` so mic/speaker capture stops the moment the user hits Ctrl-C, not whenever they finish answering the save prompt.
- `Listen.swift` opens the SessionLog only when it could plausibly be saved (either `--transcript` is set, or the renderer is TTY and stdin is interactive). A `defer` block removes the temp file on error paths so nothing leaks to `TMPDIR` if the pipeline throws.
- `Vo.swift` exposes the `--transcript <path>` flag.
- README / CLAUDE.md updated.

## Test plan

- [x] `swift build` clean
- [x] `vo --help` shows `--transcript <transcript>` with the documented description
- [ ] Interactive: `vo` then Ctrl-C → prompt appears; Enter keeps default path, `n` discards temp, custom path renames temp
- [ ] Interactive: `vo --transcript out.jsonl` with `out.jsonl` already present → `Overwrite? [y/N]` appears; `n` aborts cleanly without starting capture
- [ ] Interactive: at the save prompt, type a directory path → `<path> is a directory; choose a file path instead.` then prompt loops
- [ ] Long-running: `vo --transcript /tmp/long.jsonl` for several minutes, confirm constant RSS (no buffering)
- [ ] Non-TTY: `vo --json > out.jsonl` then Ctrl-C → no prompt, no temp file created