### PR TITLE
docs: document manual install steps and fix releases URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,17 @@ $ brew install k1LoW/tap/vo
 
 **manually:**
 
-Download binary from [releases page](https://github.com/k1LoW/voio/releases)
+Download the binary from the [releases page](https://github.com/k1LoW/vo/releases), then strip the quarantine attribute and place it on your `PATH`.
+
+```console
+$ tar -xzf vo_*_darwin_arm64.tar.gz
+$ xattr -cr vo
+$ chmod +x vo
+$ mv vo /usr/local/bin/
+```
+
+> [!NOTE]
+> `xattr -cr` strips `com.apple.quarantine` that macOS attaches to downloaded archives. Without it, Gatekeeper blocks the ad-hoc signed binary from launching.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Fill in the manual-install path in the README. Until now it only said "download from the releases page" and pointed at a typoed URL (`/voio/releases`). Anyone who actually downloaded the tarball still had to figure out for themselves that the ad-hoc signed binary needs `xattr -cr` to clear `com.apple.quarantine`, mirroring what the Homebrew formula does in its `install` step.

## Changes

- Replace the one-line "manually:" blurb with the actual command sequence (`tar -xzf`, `xattr -cr`, `chmod +x`, `mv`).
- Add a NOTE explaining *why* `xattr -cr` is required, matching the tone of the existing Homebrew NOTE just above it.
- Fix the releases-page URL (`voio` → `vo`).

## Test plan

- [x] `README.md` renders with the new install block and NOTE under "manually:"
- [ ] Follow the commands on a fresh tarball under macOS 26 to confirm the binary launches without Gatekeeper blocking it