### PR TITLE
feat: quiet down channel labels and tint timestamps by channel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ There is no global lock between the mic and speaker channels — they each const
 - The `Renderer` actor (serializes all event handling).
 - A `SeqCounter` actor (gives a monotonic `seq` across both channels so output order corresponds to which channel finalized first).
 
-This is why the mic re-capturing speaker audio (acoustic feedback) appears as duplicate `[MIC]` + `[SPK]` events with similar content. `--voice-processing` is the only software mitigation we have; otherwise the user is expected to use headphones or `--no-mic`.
+This is why the mic re-capturing speaker audio (acoustic feedback) appears as duplicate `[mic]` + `[spk]` events with similar content. `--voice-processing` is the only software mitigation we have; otherwise the user is expected to use headphones or `--no-mic`.
 
 ## Output formats
 
@@ -111,19 +111,25 @@ This is why the mic re-capturing speaker audio (acoustic feedback) appears as du
 ```
 vo 0.1.0 — listening on mic + speaker (en-US → ja-JP)
 
-08:34:56  [MIC]  How are you doing?
-                 元気ですか？
-08:34:58  [SPK]  I'm fine, thanks.
-                 元気だよ、ありがとう。
+08:34:56 [mic]  How are you doing?
+                元気ですか？
+08:34:58 [spk]  I'm fine, thanks.
+                元気だよ、ありがとう。
                                                         ← live region below
-          [MIC]  … in-progress fragment                 ← volatile, redrawn in place
+         [mic]  … in-progress fragment                  ← volatile, redrawn in place
 ```
 
-Colors (256-color palette, Terminal.app safe):
+When only one channel is active (`--no-mic` or `--no-speaker`), the `[mic]` / `[spk]` label is suppressed and source text follows the timestamp directly with a three-space gap:
 
-- `[MIC]` 166 + bold
-- `[SPK]` 38 + bold
-- Timestamp 244 (gray)
+```
+08:34:56   How are you doing?
+           元気ですか？
+```
+
+Colors (256-color palette, Terminal.app safe). Both the timestamp and the channel label use the channel's tint, so the eye reads them as one unit:
+
+- mic timestamp + `[mic]` label: 130 (amber)
+- speaker timestamp + `[spk]` label: 24 (teal)
 - Translation 244 (gray, sits behind source)
 - In-progress volatile fragment text: 244 (same dim as translation, so it reads as "not committed yet")
 - `(translating…)`, `(no translation)`, `… ` volatile leader: 240 (darker gray)

--- a/README.md
+++ b/README.md
@@ -56,13 +56,15 @@ $ vo --doctor                         # Environment diagnostics
 ```
 vo 0.1.0 — listening on mic + speaker (en-US → ja-JP)
 
-08:34:56  [MIC]  How are you doing?
-                 元気ですか？
-08:34:58  [SPK]  I'm fine, thanks.
-                 元気だよ、ありがとう。
+08:34:56 [mic]  How are you doing?
+                元気ですか？
+08:34:58 [spk]  I'm fine, thanks.
+                元気だよ、ありがとう。
 ```
 
-Translation lines are shown in dim text under the source. Pairs are emitted in source order — a slow translation holds back subsequent pairs to keep the output coherent.
+The `[mic]` / `[spk]` label is shown only when both channels are active; with `--no-mic` or `--no-speaker` it is omitted and the timestamp alone marks each line. The timestamp shares the channel's tint (amber for mic, teal for speaker), so a single glance tells you which side just spoke.
+
+Translation lines are shown in dim text under the source. Pairs are emitted in source order, so a slow translation holds back subsequent pairs to keep the output coherent.
 
 ### JSONL output
 

--- a/Sources/vo/Listen.swift
+++ b/Sources/vo/Listen.swift
@@ -51,6 +51,7 @@ func runListen(
         sourceLang: sourceLocale.identifier(.bcp47),
         targetLang: targetLocale?.identifier(.bcp47) ?? "",
         translationEnabled: targetLocale != nil,
+        showChannelLabel: mic && speaker,
         logSink: sessionLog
     )
 

--- a/Sources/vo/Renderer.swift
+++ b/Sources/vo/Renderer.swift
@@ -51,6 +51,8 @@ actor StreamRenderer: Renderer {
     private let sourceLang: String
     private let targetLang: String
     private let translationEnabled: Bool
+    private let showChannelLabel: Bool
+    private let sourceColumnPad: String
     private let logSink: SessionLog?
 
     private var commitQueue: [Pair] = []
@@ -72,6 +74,7 @@ actor StreamRenderer: Renderer {
         sourceLang: String,
         targetLang: String,
         translationEnabled: Bool = true,
+        showChannelLabel: Bool = true,
         out: FileHandle = .standardOutput,
         logSink: SessionLog? = nil
     ) {
@@ -80,6 +83,10 @@ actor StreamRenderer: Renderer {
         self.sourceLang = sourceLang
         self.targetLang = targetLang
         self.translationEnabled = translationEnabled
+        self.showChannelLabel = showChannelLabel
+        // With label: "HH:MM:SS" (8) + " " (1) + "[mic]" (5) + "  " (2) = 16.
+        // Without:    "HH:MM:SS" (8) + "   " (3)                        = 11.
+        self.sourceColumnPad = String(repeating: " ", count: showChannelLabel ? 16 : 11)
         self.logSink = logSink
     }
 
@@ -158,7 +165,7 @@ actor StreamRenderer: Renderer {
 
         switch mode {
         case .tty:
-            writeLine("\(ttyTimestamp(timing.timestamp))  \(ttyChannel(channel))  \(source)")
+            writeLine("\(ttyHeader(timing.timestamp, channel))\(source)")
         case .jsonl:
             if let jsonl { writeLine(jsonl) }
         }
@@ -173,11 +180,11 @@ actor StreamRenderer: Renderer {
 
         switch mode {
         case .tty:
-            writeLine("\(ttyTimestamp(pair.timing.timestamp))  \(ttyChannel(pair.channel))  \(pair.source)")
+            writeLine("\(ttyHeader(pair.timing.timestamp, pair.channel))\(pair.source)")
             if let target {
-                writeLine("\(Self.sourceColumnPad)\u{001B}[38;5;244m\(target)\u{001B}[0m")
+                writeLine("\(sourceColumnPad)\u{001B}[38;5;244m\(target)\u{001B}[0m")
             } else {
-                writeLine("\(Self.sourceColumnPad)\u{001B}[38;5;240m(no translation)\u{001B}[0m")
+                writeLine("\(sourceColumnPad)\u{001B}[38;5;240m(no translation)\u{001B}[0m")
             }
         case .jsonl:
             if let jsonl { writeLine(jsonl) }
@@ -203,23 +210,35 @@ actor StreamRenderer: Renderer {
 
     // MARK: - TTY formatting helpers
 
-    /// Source text starts at column 17 = "HH:MM:SS" (8) + "  " (2) + "[MIC]" (5) + "  " (2).
-    /// Translation and (translating…) lines are indented to align with source text.
-    private static let sourceColumnPad = String(repeating: " ", count: 17)
+    /// Pad to where [mic]/[spk] starts on volatile lines (no timestamp). Only used
+    /// when channel labels are shown.
+    private static let channelColumnPad = String(repeating: " ", count: 9)
 
-    /// Pad to where [MIC]/[SPK] starts on volatile lines (no timestamp).
-    private static let channelColumnPad = String(repeating: " ", count: 10)
+    /// 256-color palette code for the given channel. Shared by the timestamp and
+    /// the [mic]/[spk] label so the eye reads both as the same channel.
+    private func channelColor(_ channel: AudioChannel) -> Int {
+        switch channel {
+        case .mic:     return 130
+        case .speaker: return 24
+        }
+    }
 
-    private func ttyTimestamp(_ date: Date) -> String {
+    private func ttyTimestamp(_ date: Date, channel: AudioChannel) -> String {
         let s = StreamRenderer.ttyTime.string(from: date)
-        return "\u{001B}[38;5;244m\(s)\u{001B}[0m"
+        return "\u{001B}[38;5;\(channelColor(channel))m\(s)\u{001B}[0m"
     }
 
     private func ttyChannel(_ channel: AudioChannel) -> String {
-        switch channel {
-        case .mic:     return "\u{001B}[1;38;5;166m[MIC]\u{001B}[0m"  // bold darker orange
-        case .speaker: return "\u{001B}[1;38;5;38m[SPK]\u{001B}[0m"   // bold darker cyan
-        }
+        let label = (channel == .mic) ? "[mic]" : "[spk]"
+        return "\u{001B}[38;5;\(channelColor(channel))m\(label)\u{001B}[0m"
+    }
+
+    /// Build the leading "<timestamp> [mic]  " (or "<timestamp>   " when only one
+    /// channel is active and the label is suppressed) segment.
+    private func ttyHeader(_ timestamp: Date, _ channel: AudioChannel) -> String {
+        showChannelLabel
+            ? "\(ttyTimestamp(timestamp, channel: channel)) \(ttyChannel(channel))  "
+            : "\(ttyTimestamp(timestamp, channel: channel))   "
     }
 
     private func jsonlBase(seq: Int, channel: AudioChannel, timing: ChunkTiming) -> [String: Any] {
@@ -264,8 +283,8 @@ actor StreamRenderer: Renderer {
         // Pending pairs (translation not yet arrived) plus per-channel volatile lines.
         var lines: [String] = []
         for pair in commitQueue where pair.target == nil {
-            lines.append("\(ttyTimestamp(pair.timing.timestamp))  \(ttyChannel(pair.channel))  \(pair.source)")
-            lines.append("\(Self.sourceColumnPad)\u{001B}[38;5;240m(translating…)\u{001B}[0m")
+            lines.append("\(ttyHeader(pair.timing.timestamp, pair.channel))\(pair.source)")
+            lines.append("\(sourceColumnPad)\u{001B}[38;5;240m(translating…)\u{001B}[0m")
         }
         for channel in AudioChannel.allCases {
             if let v = volatileTexts[channel], !v.isEmpty {
@@ -275,7 +294,11 @@ actor StreamRenderer: Renderer {
                 // rather than as the start of the fragment text itself.
                 let leader = "\u{001B}[38;5;240m… \u{001B}[0m"
                 let body = "\u{001B}[38;5;244m\(v)\u{001B}[0m"
-                lines.append("\(Self.channelColumnPad)\(ttyChannel(channel))  \(leader)\(body)")
+                if showChannelLabel {
+                    lines.append("\(Self.channelColumnPad)\(ttyChannel(channel))  \(leader)\(body)")
+                } else {
+                    lines.append("\(sourceColumnPad)\(leader)\(body)")
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

The previous TTY presentation overemphasized the channel marker. `[MIC]` and `[SPK]` rendered in bold orange / cyan, taking visual weight away from the transcription text, and the timestamp stayed neutral gray so the eye had to refocus on the bracket label to figure out which side just spoke.

Quiet the marker down so it reads as metadata, and move the channel signal onto the timestamp itself so each line opens with its own identity. When only one channel is active, the bracket label adds no information, so suppress it entirely and let the (now tinted) timestamp carry the channel by itself.

## Changes

- Lowercase `[mic]` / `[spk]`, no bold, darker 256-color palette (mic 130 amber, spk 24 teal).
- Timestamp now shares the channel tint via a `channelColor(_:)` helper used by both `ttyTimestamp` and `ttyChannel`, so the leading `13:17:58 [mic]` reads as one colored unit.
- Tighten the gap between timestamp and label from two spaces to one. Keep two spaces between label and source so translation lines still align cleanly under the source text.
- New `showChannelLabel` flag on `StreamRenderer`. `Listen.swift` passes `mic && speaker`, so a `--no-mic` or `--no-speaker` session drops the bracket label entirely. `sourceColumnPad` becomes an instance `let` and switches between 16 (label shown) and 11 (label suppressed, source sits three spaces after the timestamp).
- `redrawLiveRegion` branches between the labeled and unlabeled volatile layouts so in-progress fragments and `(translating…)` rows realign under source in both modes.
- README and CLAUDE.md updated with the new sample output, color cheatsheet, and single-channel layout note.

## Test plan

- [x] `swift build` clean
- [ ] Interactive: `vo` with both channels active. Confirm timestamps and `[mic]` / `[spk]` share the channel tint, neither is bold, and there is exactly one space between timestamp and label.
- [ ] Interactive: `vo --no-speaker`. Confirm `[mic]` is suppressed, the timestamp is amber, and source text starts three spaces after the timestamp.
- [ ] Interactive: `vo --no-mic --src en-US --dst ja-JP`. Confirm timestamps are teal and translation lines align under source.
- [ ] Interactive: volatile fragments and `(translating…)` placeholders align under source in both labeled and unlabeled modes; live region clears cleanly on Ctrl-C.
- [ ] `vo --json` output is unchanged (the `channel` field stays in every record regardless of TTY display).