### PR TITLE
fix: correctness and stability bugs surfaced by live runs

### DIFF
--- a/Sources/vo/AudioSource.swift
+++ b/Sources/vo/AudioSource.swift
@@ -172,13 +172,17 @@ extension CMSampleBuffer {
         )
         guard status == noErr else { return nil }
 
-        // Copy from the source ABL into the freshly allocated PCM buffer.
-        let srcList = UnsafeMutableAudioBufferListPointer(ablPtr)
-        let dstList = UnsafeMutableAudioBufferListPointer(buffer.mutableAudioBufferList)
-        for i in 0..<min(srcList.count, dstList.count) {
-            let copyBytes = Int(min(srcList[i].mDataByteSize, dstList[i].mDataByteSize))
-            if let s = srcList[i].mData, let d = dstList[i].mData {
-                memcpy(d, s, copyBytes)
+        // Copy from the source ABL into the freshly allocated PCM buffer. The ABL's
+        // mData pointers point into blockBuffer, and ARC is free to release it after
+        // its last use above, so pin it for the duration of the copy.
+        withExtendedLifetime(blockBuffer) {
+            let srcList = UnsafeMutableAudioBufferListPointer(ablPtr)
+            let dstList = UnsafeMutableAudioBufferListPointer(buffer.mutableAudioBufferList)
+            for i in 0..<min(srcList.count, dstList.count) {
+                let copyBytes = Int(min(srcList[i].mDataByteSize, dstList[i].mDataByteSize))
+                if let s = srcList[i].mData, let d = dstList[i].mData {
+                    memcpy(d, s, copyBytes)
+                }
             }
         }
         return buffer

--- a/Sources/vo/Devices.swift
+++ b/Sources/vo/Devices.swift
@@ -90,14 +90,21 @@ private func queryInputChannelCount(_ deviceID: AudioDeviceID) throws -> Int {
     )
     var size: UInt32 = 0
     var status = AudioObjectGetPropertyDataSize(deviceID, &address, 0, nil, &size)
+    guard status == noErr, size > 0 else { return 0 }
+
+    // AudioBufferList is variable-length; devices with multiple streams report a
+    // size larger than a single AudioBufferList, so allocate the reported size
+    // instead of one fixed-size element.
+    let raw = UnsafeMutableRawPointer.allocate(
+        byteCount: Int(size),
+        alignment: MemoryLayout<AudioBufferList>.alignment
+    )
+    defer { raw.deallocate() }
+    let listPtr = raw.bindMemory(to: AudioBufferList.self, capacity: 1)
+    status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, listPtr)
     guard status == noErr else { return 0 }
 
-    let buffer = UnsafeMutablePointer<AudioBufferList>.allocate(capacity: 1)
-    defer { buffer.deallocate() }
-    status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, buffer)
-    guard status == noErr else { return 0 }
-
-    let abl = UnsafeMutableAudioBufferListPointer(buffer)
+    let abl = UnsafeMutableAudioBufferListPointer(listPtr)
     var channels = 0
     for i in 0..<abl.count {
         channels += Int(abl[i].mNumberChannels)

--- a/Sources/vo/Listen.swift
+++ b/Sources/vo/Listen.swift
@@ -116,8 +116,12 @@ func runListen(
     } else {
         // The SIGINT handler claimed finalization and will exit the process.
         // Returning here would tear it down mid-prompt, so park until that exit.
+        // The handler calls Foundation.exit long before one interval elapses, so
+        // a long interval (rather than once per second) just avoids needless
+        // wakeups while we wait. The loop reparks if the sleep is ever cancelled.
+        let parkInterval: UInt64 = 3600 * 1_000_000_000  // 1 hour
         while true {
-            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            try? await Task.sleep(nanoseconds: parkInterval)
         }
     }
 }

--- a/Sources/vo/Listen.swift
+++ b/Sources/vo/Listen.swift
@@ -69,6 +69,12 @@ func runListen(
         printBanner(sourceLocale: sourceLocale, targetLocale: targetLocale, mic: mic, speaker: speaker)
     }
 
+    // pipeline.cancel() lets pipeline.run() below return, so after SIGINT the natural
+    // completion path races the handler to finalizeSession. The gate makes exactly one
+    // of them finalize (a double run would print the save prompt and summary twice and
+    // have two readLine calls fighting over stdin).
+    let finalizeGate = FinalizeGate()
+
     let signalSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
     signalSource.setEventHandler {
         Task {
@@ -76,6 +82,12 @@ func runListen(
             // and speaker capture keep running for as long as the user is reading
             // the prompt, which is wasted work and a small privacy footgun.
             await pipeline.cancel()
+            guard await finalizeGate.claim() else {
+                // Finalization is already underway (a repeat Ctrl-C, likely at the
+                // save prompt). Abort hard but leave the temp file in place so the
+                // captured session is still recoverable.
+                Foundation.exit(130)
+            }
             await renderer.handle(.eof)
             await renderer.flush()
             let count = await renderer.utteranceCount
@@ -93,13 +105,34 @@ func runListen(
 
     try await pipeline.run()
 
-    let count = await renderer.utteranceCount
-    await finalizeSession(
-        sessionLog: sessionLog,
-        isTTY: isTTY,
-        count: count,
-        duration: Date().timeIntervalSince(startedAt)
-    )
+    if await finalizeGate.claim() {
+        let count = await renderer.utteranceCount
+        await finalizeSession(
+            sessionLog: sessionLog,
+            isTTY: isTTY,
+            count: count,
+            duration: Date().timeIntervalSince(startedAt)
+        )
+    } else {
+        // The SIGINT handler claimed finalization and will exit the process.
+        // Returning here would tear it down mid-prompt, so park until that exit.
+        while true {
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+        }
+    }
+}
+
+/// One-shot gate so the SIGINT handler and the natural completion path cannot both
+/// run finalizeSession.
+private actor FinalizeGate {
+    private var claimed = false
+
+    /// Returns `true` exactly once; every later call returns `false`.
+    func claim() -> Bool {
+        if claimed { return false }
+        claimed = true
+        return true
+    }
 }
 
 /// Close the session log, run save/discard logic, then print the exit summary.

--- a/Sources/vo/Pipeline.swift
+++ b/Sources/vo/Pipeline.swift
@@ -200,8 +200,14 @@ struct Pipeline {
         // Drain transcriber results.
         do {
             for try await result in transcriber.results {
-                let text = String(result.text.characters)
+                // SpeechTranscriber emits every chunk after the first with a leading
+                // space (stream-concatenation artifact). Trim so TTY columns stay
+                // aligned and the space doesn't leak into JSONL or translation input.
+                let text = String(result.text.characters).trimmingCharacters(in: .whitespacesAndNewlines)
                 if result.isFinal {
+                    // Whitespace-only finals carry no content; skip them so they
+                    // don't burn a seq or emit blank lines.
+                    guard !text.isEmpty else { continue }
                     let seq = await counter.next()
                     let timing = ChunkTiming(
                         timestamp: Date(),

--- a/Sources/vo/Renderer.swift
+++ b/Sources/vo/Renderer.swift
@@ -102,8 +102,11 @@ actor StreamRenderer: Renderer {
             finalizedCount += 1
             if translationEnabled {
                 commitQueue.append(Pair(seq: seq, channel: channel, source: source, timing: timing, target: nil))
-                if mode == .tty { redrawLiveRegion() }
+                // Drain before redrawing: drainCommitQueue clears the live region
+                // as a side effect, so the reverse order would blank the pending
+                // "(translating…)" lines until the next event arrives.
                 drainCommitQueue()
+                if mode == .tty { redrawLiveRegion() }
             } else {
                 // No translation: commit immediately, source-only.
                 if mode == .tty { clearLiveRegion() }

--- a/Sources/vo/Renderer.swift
+++ b/Sources/vo/Renderer.swift
@@ -102,7 +102,7 @@ actor StreamRenderer: Renderer {
             finalizedCount += 1
             if translationEnabled {
                 commitQueue.append(Pair(seq: seq, channel: channel, source: source, timing: timing, target: nil))
-                // Drain before redrawing: drainCommitQueue clears the live region
+                // Drain before redrawing. drainCommitQueue clears the live region
                 // as a side effect, so the reverse order would blank the pending
                 // "(translating…)" lines until the next event arrives.
                 drainCommitQueue()


### PR DESCRIPTION
## Summary

Running `vo` live against a long mic + speaker session surfaced a cluster of independent bugs across the audio, render, and shutdown paths. None changed the architecture; each is a correctness or stability fix, kept as its own commit so they can be reviewed and reverted independently.

Two of them are latent memory hazards that a debug build hides. The input-device enumeration under-allocated a variable-length `AudioBufferList` and let Core Audio write past it, and the speaker-channel PCM copy read from a block buffer that ARC could already have released. The rest are user-visible: source text drifting one column right from the second utterance on, a just-finalized TTY line flickering out, and a double save-prompt / summary on Ctrl-C.

## Changes

- **`Devices.swift`** — allocate the size Core Audio reports for the input channel-count `AudioBufferList` instead of a fixed `capacity: 1`. A device with more than one input stream reports a larger size, so the old allocation let `AudioObjectGetPropertyData` corrupt the heap (aggregate / some virtual devices).
- **`AudioSource.swift`** — wrap the `CMSampleBuffer` → PCM copy in `withExtendedLifetime(blockBuffer)`. The audio buffer list's `mData` aliases into the block buffer, which ARC could release before the `memcpy`; in release builds that was a read of freed memory on every speaker buffer.
- **`Pipeline.swift`** — trim leading/trailing whitespace off each transcriber chunk and skip whitespace-only finals. `SpeechTranscriber` prefixes every chunk after the first with a space, which was shifting TTY source columns and leaking into `src.text` and the translation input.
- **`Renderer.swift`** — drain the commit queue before redrawing the live region on a finalized chunk. `drainCommitQueue` clears the live region as a side effect, so the previous order wiped the line it had just drawn until the next event arrived.
- **`Listen.swift`** — add a one-shot `FinalizeGate` so the SIGINT handler and the natural-completion path can't both run `finalizeSession`. `pipeline.cancel()` lets `pipeline.run()` return, so after Ctrl-C both paths raced, double-printing the save prompt / summary and fighting over stdin.

## Test plan

- [x] `swift build` clean
- [x] Interactive: `vo --src en-US --dst ja-JP --no-speaker` (mic) — source lines stay column-aligned from the first utterance on; one save prompt and one summary on Ctrl-C
- [ ] Interactive: `vo --src en-US --dst ja-JP --no-mic` (speaker) — no crash / audio corruption over a multi-minute session (exercises the block-buffer lifetime fix)
- [ ] Interactive: confirm a just-finalized TTY line no longer flickers out before its translation arrives
- [ ] `vo --doctor` lists input devices without crashing on a machine with an aggregate / multi-stream input device
- [ ] Repeat Ctrl-C at the save prompt exits cleanly (130) and leaves the temp transcript recoverable