### PR TITLE
test: add Swift Testing suite and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: macos-26
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Show toolchain
+        run: |
+          sw_vers
+          xcode-select -p
+          swift --version
+
+      - name: Build
+        run: swift build
+
+      - name: Test
+        run: ./scripts/test.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,21 @@ swift build -c release --arch arm64    # release
 .build/debug/vo --doctor               # environment check (no TCC required)
 ```
 
-There are no tests yet.
+## Test
+
+```bash
+./scripts/test.sh                      # Swift Testing suite (swift test under the hood)
+```
+
+Tests use Swift Testing (`import Testing`, `@Test`) in `Tests/voTests/`. They cover only the
+TCC-free pure logic: `StreamRenderer` JSONL output (source-order commit, volatile suppression,
+null-target on EOF), `VoError` messages, and `detectRenderMode`. The audio / Speech / Translation
+paths require TCC grants and macOS 26 hardware, so they are not unit-tested.
+
+`scripts/test.sh` exists because on a Command Line Tools-only install (no full Xcode) the Swift
+Testing framework and its `lib_TestingInterop` dylib are off the default search / rpath; the script
+injects the needed `-F` / `-rpath` flags only when that layout is detected. Under full Xcode (CI's
+`macos-26` runner) it runs a plain `swift test`. CI lives in `.github/workflows/test.yml`.
 
 ## Runtime requirements
 

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,11 @@ let package = Package(
                 .product(name: "ArgumentParser", package: "swift-argument-parser")
             ],
             path: "Sources/vo"
+        ),
+        .testTarget(
+            name: "voTests",
+            dependencies: ["vo"],
+            path: "Tests/voTests"
         )
     ]
 )

--- a/Tests/voTests/RenderModeTests.swift
+++ b/Tests/voTests/RenderModeTests.swift
@@ -1,0 +1,9 @@
+import Testing
+@testable import vo
+
+@Suite("detectRenderMode")
+struct RenderModeTests {
+    @Test func jsonForcedAlwaysSelectsJSONL() {
+        #expect(detectRenderMode(jsonForced: true) == .jsonl)
+    }
+}

--- a/Tests/voTests/RendererTests.swift
+++ b/Tests/voTests/RendererTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+@testable import vo
+
+/// Drives a `StreamRenderer` in JSONL mode against an in-memory pipe and returns the
+/// emitted lines parsed back into dictionaries, so tests can assert on the wire format
+/// without touching any audio / Speech / Translation framework.
+private func renderJSONL(
+    translationEnabled: Bool,
+    showChannelLabel: Bool = true,
+    _ body: (StreamRenderer) async -> Void
+) async -> [[String: Any]] {
+    let pipe = Pipe()
+    let renderer = StreamRenderer(
+        mode: .jsonl,
+        sourceLang: "en-US",
+        targetLang: translationEnabled ? "ja-JP" : "",
+        translationEnabled: translationEnabled,
+        showChannelLabel: showChannelLabel,
+        out: pipe.fileHandleForWriting
+    )
+
+    await body(renderer)
+    await renderer.handle(.eof)
+    await renderer.flush()
+
+    try? pipe.fileHandleForWriting.close()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    let text = String(decoding: data, as: UTF8.self)
+    return text
+        .split(separator: "\n")
+        .compactMap {
+            guard let d = $0.data(using: .utf8) else { return nil }
+            return (try? JSONSerialization.jsonObject(with: d)) as? [String: Any]
+        }
+}
+
+private let timing = ChunkTiming(
+    timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+    audioStart: 0.124,
+    audioEnd: 1.582
+)
+
+private func src(_ obj: [String: Any]) -> [String: Any]? { obj["src"] as? [String: Any] }
+private func dst(_ obj: [String: Any]) -> [String: Any]? { obj["dst"] as? [String: Any] }
+
+@Suite("StreamRenderer JSONL")
+struct RendererTests {
+    /// Invariant: strict source-order commit. A translation that arrives early for a
+    /// later chunk must not jump ahead of an untranslated earlier chunk.
+    @Test func commitsInSourceOrderDespiteOutOfOrderTranslations() async {
+        let objs = await renderJSONL(translationEnabled: true) { r in
+            await r.handle(.finalized(channel: .mic, seq: 0, source: "Hello", timing: timing))
+            await r.handle(.finalized(channel: .speaker, seq: 1, source: "World", timing: timing))
+            // seq 1 finishes translating first, but seq 0 is still pending.
+            await r.handle(.translated(seq: 1, target: "世界"))
+            await r.handle(.translated(seq: 0, target: "こんにちは"))
+        }
+
+        #expect(objs.count == 2)
+        #expect(objs.compactMap { $0["seq"] as? Int } == [0, 1])
+        #expect(src(objs[0])?["text"] as? String == "Hello")
+        #expect(dst(objs[0])?["text"] as? String == "こんにちは")
+        #expect(src(objs[1])?["text"] as? String == "World")
+        #expect(dst(objs[1])?["text"] as? String == "世界")
+    }
+
+    /// Invariant: volatile (partial) updates never reach JSONL.
+    @Test func volatileUpdatesAreNotEmitted() async {
+        let objs = await renderJSONL(translationEnabled: true) { r in
+            await r.handle(.volatile(channel: .mic, text: "in prog"))
+            await r.handle(.finalized(channel: .mic, seq: 0, source: "final", timing: timing))
+            await r.handle(.translated(seq: 0, target: "確定"))
+        }
+
+        #expect(objs.count == 1)
+        #expect(src(objs[0])?["text"] as? String == "final")
+    }
+
+    /// Without a target locale the renderer is transcribe-only: no `dst` key, and the
+    /// chunk commits immediately (no translation gate).
+    @Test func transcribeOnlyOmitsDst() async {
+        let objs = await renderJSONL(translationEnabled: false, showChannelLabel: false) { r in
+            await r.handle(.finalized(channel: .mic, seq: 0, source: "no translation", timing: timing))
+        }
+
+        #expect(objs.count == 1)
+        #expect(objs[0]["dst"] == nil)
+        #expect(src(objs[0])?["text"] as? String == "no translation")
+    }
+
+    /// On EOF, a chunk whose translation never arrived is force-committed with an
+    /// explicit JSON null `dst.text`.
+    @Test func eofForceCommitsUntranslatedWithNullTarget() async {
+        let objs = await renderJSONL(translationEnabled: true) { r in
+            await r.handle(.finalized(channel: .mic, seq: 0, source: "lonely", timing: timing))
+        }
+
+        #expect(objs.count == 1)
+        #expect(dst(objs[0])?["lang"] as? String == "ja-JP")
+        #expect(dst(objs[0])?["text"] is NSNull)
+    }
+
+    /// Audio range from the transcriber is echoed into the JSONL `audio` object.
+    @Test func audioRangeIsEmitted() async {
+        let objs = await renderJSONL(translationEnabled: false) { r in
+            await r.handle(.finalized(channel: .speaker, seq: 0, source: "x", timing: timing))
+        }
+
+        let audio = objs[0]["audio"] as? [String: Any]
+        #expect(audio?["start"] as? Double == 0.124)
+        #expect(audio?["end"] as? Double == 1.582)
+        #expect(objs[0]["channel"] as? String == "speaker")
+    }
+}

--- a/Tests/voTests/VoErrorTests.swift
+++ b/Tests/voTests/VoErrorTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+@testable import vo
+
+@Suite("VoError messages")
+struct VoErrorTests {
+    /// An unsupported locale whose language has supported regional variants should
+    /// suggest exactly those variants and nothing from other languages.
+    @Test func unsupportedLocaleSuggestsRegionalVariants() {
+        let err = VoError.unsupportedSpeechLocale(
+            Locale(identifier: "en"),
+            supported: ["en-US", "en-GB", "ja-JP"]
+        )
+        let msg = err.description
+
+        #expect(msg.contains("regional variants"))
+        #expect(msg.contains("en-US"))
+        #expect(msg.contains("en-GB"))
+        #expect(!msg.contains("ja-JP"))
+    }
+
+    /// When no regional variant matches, fall back to pointing at `--doctor`.
+    @Test func unsupportedLocaleWithoutNearbyPointsToDoctor() {
+        let err = VoError.unsupportedSpeechLocale(
+            Locale(identifier: "xx"),
+            supported: ["en-US", "ja-JP"]
+        )
+        let msg = err.description
+
+        #expect(msg.contains("--doctor"))
+        #expect(!msg.contains("regional variants"))
+    }
+}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -25,4 +25,6 @@ if [ -d "$CLT_FRAMEWORKS/Testing.framework" ]; then
     )
 fi
 
-exec swift test "${EXTRA[@]}" "$@"
+# `${EXTRA[@]+...}` so an empty array does not trip `set -u` (older bash treats an
+# empty array reference as an unbound variable, which is what CI's bash does).
+exec swift test ${EXTRA[@]+"${EXTRA[@]}"} "$@"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Run the Swift Testing suite via SwiftPM.
+#
+# Under a full Xcode toolchain (e.g. GitHub's macos runners) `swift test` resolves
+# the Swift Testing framework on its own, so no extra flags are needed. Under a
+# Command Line Tools-only install the Testing.framework and its lib_TestingInterop
+# dylib are not on the default search / rpath, so we wire them up explicitly.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+DEV="$(xcode-select -p)"
+CLT_FRAMEWORKS="$DEV/Library/Developer/Frameworks"
+CLT_INTEROP="$DEV/Library/Developer/usr/lib"
+
+EXTRA=()
+if [ -d "$CLT_FRAMEWORKS/Testing.framework" ]; then
+    # Command Line Tools layout: point the compiler at the framework and add both
+    # the framework dir and the interop dylib dir to the runtime search path.
+    EXTRA=(
+        -Xswiftc -F -Xswiftc "$CLT_FRAMEWORKS"
+        -Xlinker -rpath -Xlinker "$CLT_FRAMEWORKS"
+        -Xlinker -rpath -Xlinker "$CLT_INTEROP"
+    )
+fi
+
+exec swift test "${EXTRA[@]}" "$@"


### PR DESCRIPTION
## Summary

`vo` had no tests. This adds a modern Swift Testing suite plus a CI workflow so the parts that don't need TCC or macOS 26 hardware are covered and stay green on every push.

The whole pipeline is gated behind microphone / speech / screen-recording permissions and Neural Engine hardware, so audio capture, `SpeechTranscriber`, and `TranslationSession` can't run headless. What can be tested in isolation is the pure logic those paths feed into, above all the `StreamRenderer` ordering invariants documented in CLAUDE.md. The suite targets exactly that surface and leaves the hardware paths out of scope rather than mocking Apple frameworks.

Tests run against the `vo` executable target via `@testable import vo`, which works on the current SwiftPM toolchain, so no library split was needed.

## Changes

- **`Tests/voTests/RendererTests.swift`** — drive `StreamRenderer` in JSONL mode through an in-memory `Pipe` and assert the wire format: strict source-order commit despite out-of-order translations, volatile updates never reaching JSONL, transcribe-only omitting `dst`, `dst.text: null` force-commit on EOF, and the `audio` range echo.
- **`Tests/voTests/VoErrorTests.swift`** — `VoError.unsupportedSpeechLocale` suggests only matching regional variants, and falls back to the `--doctor` hint when none match.
- **`Tests/voTests/RenderModeTests.swift`** — `detectRenderMode(jsonForced:)` always selects JSONL when forced.
- **`Package.swift`** — add the `voTests` test target.
- **`scripts/test.sh`** — wrapper around `swift test`. On a Command Line Tools-only install the Swift Testing framework and its `lib_TestingInterop` dylib are off the default search / rpath, so the script injects the `-F` / `-rpath` flags only when that layout is detected; under full Xcode (CI's `macos-26` runner) it runs a plain `swift test`.
- **`.github/workflows/test.yml`** — run `swift build` and `./scripts/test.sh` on `macos-26` for push / PR, matching the runner and SHA-pinned actions already used by `tagpr.yml`.
- **`CLAUDE.md`** — document the `## Test` workflow.

## Test plan

- [x] `swift build` clean
- [x] `./scripts/test.sh` — 8 tests in 3 suites pass locally (Command Line Tools-only toolchain, flags injected)
- [x] `.build/debug/vo --version` still prints `0.2.1`
- [x] CI green on the `macos-26` runner (plain `swift test`, no injected flags)