### PR TITLE
feat: use a Core Audio tap for speaker capture to drop Screen Recording

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ injects the needed `-F` / `-rpath` flags only when that layout is detected. Unde
 
 - macOS 26+ (uses `SpeechTranscriber`, `SpeechAnalyzer`, `TranslationSession`, all macOS 26 only)
 - Apple Silicon (Neural Engine)
-- TCC permissions granted on first run: Microphone, Speech Recognition, and (if `--speaker` is enabled) Screen Recording. When launched from Terminal.app, the grants attach to Terminal.app rather than `vo` itself unless `vo` is properly bundled and signed.
+- TCC permissions granted on first run: Microphone, Speech Recognition, and (if `--speaker` is enabled) Audio Recording. The speaker channel uses a Core Audio process tap, **not** ScreenCaptureKit, so it needs only the Audio Recording grant, never Screen Recording. When launched from Terminal.app, the grants attach to Terminal.app rather than `vo` itself unless `vo` is properly bundled and signed.
 
 ## CLI surface
 
@@ -94,7 +94,7 @@ The whole pipeline is one TaskGroup orchestrating two parallel channels (mic + s
 | `Vo.swift` | `@main` `AsyncParsableCommand`. Pure flag-parse and dispatch to either `runListen` or `runDoctor`. |
 | `Listen.swift` | Entry point for the main capture loop. Sets up `StreamRenderer`, `Pipeline`, SIGINT handler, banner, exit summary. |
 | `Pipeline.swift` | The TaskGroup orchestration. Spawns `runChannel(.mic, …)` and `runChannel(.speaker, …)` concurrently. Each channel constructs its own `SpeechTranscriber`, `SpeechAnalyzer`, and (if translating) `TranslationSession`. **Important: `TranslationSession` is a non-Sendable class; it is constructed inside the Task closure to avoid Sendable warnings — do not hoist it.** Also contains `convertBuffer` and `VoError`. |
-| `AudioSource.swift` | `MicCapture` (AVAudioEngine input node) and `SpeakerCapture` (ScreenCaptureKit `SCStream` with `capturesAudio = true`). Both expose `AsyncStream<AVAudioPCMBuffer>`. Includes `CMSampleBuffer.asPCMBuffer()` and `AVAudioPCMBuffer.copy()` extensions. |
+| `AudioSource.swift` | `MicCapture` (AVAudioEngine input node) and `SpeakerCapture` (Core Audio process tap: `CATapDescription` + `AudioHardwareCreateProcessTap`, mounted on a private aggregate device with an IOProc). Both expose `AsyncStream<AVAudioPCMBuffer>`. Includes the `AVAudioPCMBuffer.copy()` extension and `CoreAudioError`. |
 | `Renderer.swift` | `StreamRenderer` actor + `RenderEvent` + `ChunkTiming`. Owns the strict-order commit queue, the volatile live region, the TTY rendering, the JSONL emission, the wall-clock timestamp formatting, and the wrap-aware screen-row accounting. |
 | `Doctor.swift` | `runDoctor(json:)`. Gathers OS info, speech model status, translation language list, input device list via the helpers below, then renders human text or JSON. |
 | `Locales.swift` | `collectSpeechLocales()` and `collectTranslationLanguages()`. Pure data collection, no I/O. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ injects the needed `-F` / `-rpath` flags only when that layout is detected. Unde
 
 - macOS 26+ (uses `SpeechTranscriber`, `SpeechAnalyzer`, `TranslationSession`, all macOS 26 only)
 - Apple Silicon (Neural Engine)
-- TCC permissions granted on first run: Microphone, Speech Recognition, and (if `--speaker` is enabled) Audio Recording. The speaker channel uses a Core Audio process tap, **not** ScreenCaptureKit, so it needs only the Audio Recording grant, never Screen Recording. When launched from Terminal.app, the grants attach to Terminal.app rather than `vo` itself unless `vo` is properly bundled and signed.
+- TCC permissions granted on first run: Microphone, Speech Recognition, and (unless `--no-speaker` is passed) Audio Recording. The speaker channel uses a Core Audio process tap, **not** ScreenCaptureKit, so it needs only the Audio Recording grant, never Screen Recording. When launched from Terminal.app, the grants attach to Terminal.app rather than `vo` itself unless `vo` is properly bundled and signed.
 
 ## CLI surface
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Translation lines are shown in dim text under the source. Pairs are emitted in s
 
 - macOS 26+
 - Apple Silicon (Neural Engine)
-- TCC permissions: Microphone, Speech Recognition, and Screen Recording (only when `--speaker` is enabled)
+- TCC permissions: Microphone, Speech Recognition, and Audio Recording (only when `--speaker` is enabled)
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Translation lines are shown in dim text under the source. Pairs are emitted in s
 
 - macOS 26+
 - Apple Silicon (Neural Engine)
-- TCC permissions: Microphone, Speech Recognition, and Audio Recording (only when `--speaker` is enabled)
+- TCC permissions: Microphone, Speech Recognition, and Audio Recording (speaker capture is on by default; disable it with `--no-speaker`)
 
 ## Build
 

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -20,7 +20,7 @@
     <string>vo はマイク入力から文字起こしと翻訳を行うためにマイクを使用します。</string>
     <key>NSSpeechRecognitionUsageDescription</key>
     <string>vo はオンデバイスの音声認識でマイク入力を文字起こしします。すべての処理は端末上で完結します。</string>
-    <key>NSScreenCaptureUsageDescription</key>
-    <string>vo は他アプリの音声 (会議の相手の声など) を文字起こしするために、ScreenCaptureKit 経由でシステム音声を取得します。画面の映像は使用しません。</string>
+    <key>NSAudioCaptureUsageDescription</key>
+    <string>vo は他アプリの音声 (会議の相手の声など) を文字起こしするために、システム音声を取得します。画面の映像は取得しません。</string>
 </dict>
 </plist>

--- a/Sources/vo/AudioSource.swift
+++ b/Sources/vo/AudioSource.swift
@@ -73,6 +73,9 @@ final class SpeakerCapture: @unchecked Sendable {
     private var tapID = AudioObjectID(kAudioObjectUnknown)
     private var aggregateID = AudioObjectID(kAudioObjectUnknown)
     private var ioProcID: AudioDeviceIOProcID?
+    // Runs the IOProc off Core Audio's real-time IO thread: the block deep-copies
+    // and yields into an AsyncStream, neither of which is safe on the RT thread.
+    private let ioQueue = DispatchQueue(label: "vo.spk.audio")
 
     init() {
         let (s, b) = AsyncStream<AVAudioPCMBuffer>.makeStream()
@@ -81,6 +84,18 @@ final class SpeakerCapture: @unchecked Sendable {
     }
 
     func start() async throws {
+        // Any step past the first allocation can throw, and Pipeline.runChannel only
+        // registers stop() once start() returns. So clean up partial allocations here
+        // before rethrowing, otherwise the tap / aggregate would dangle.
+        do {
+            try await startUnchecked()
+        } catch {
+            await stop()
+            throw error
+        }
+    }
+
+    private func startUnchecked() async throws {
         // Global system-output tap. vo never plays audio, so there is nothing of
         // our own to exclude from the mix.
         let tapDescription = CATapDescription(stereoGlobalTapButExcludeProcesses: [])
@@ -127,7 +142,7 @@ final class SpeakerCapture: @unchecked Sendable {
 
         let builder = self.builder
         var procID: AudioDeviceIOProcID?
-        status = AudioDeviceCreateIOProcIDWithBlock(&procID, aggregate, nil) { _, inInputData, _, _, _ in
+        status = AudioDeviceCreateIOProcIDWithBlock(&procID, aggregate, ioQueue) { _, inInputData, _, _, _ in
             // The no-copy buffer aliases Core Audio's IO memory; downstream consumers
             // run async and must own their data, so deep-copy before yielding.
             guard let aliased = AVAudioPCMBuffer(pcmFormat: format, bufferListNoCopy: inInputData),

--- a/Sources/vo/AudioSource.swift
+++ b/Sources/vo/AudioSource.swift
@@ -1,7 +1,7 @@
 import Foundation
 @preconcurrency import AVFoundation
-@preconcurrency import ScreenCaptureKit
-import CoreMedia
+import CoreAudio
+import AudioToolbox
 
 enum AudioChannel: String, Sendable, CaseIterable {
     case mic
@@ -63,59 +63,148 @@ final class MicCapture: @unchecked Sendable {
     }
 }
 
-/// System audio (speaker) capture using ScreenCaptureKit.
-/// Requires Screen Recording TCC permission.
-final class SpeakerCapture: NSObject, @unchecked Sendable {
+/// System audio (speaker) capture using Core Audio process taps (macOS 14.4+).
+/// Requires the Audio Recording TCC permission, not Screen Recording: ScreenCaptureKit
+/// would force a screen-capture grant even though vo only ever wanted the audio.
+final class SpeakerCapture: @unchecked Sendable {
     let stream: AsyncStream<AVAudioPCMBuffer>
     private let builder: AsyncStream<AVAudioPCMBuffer>.Continuation
-    private var scStream: SCStream?
 
-    override init() {
+    private var tapID = AudioObjectID(kAudioObjectUnknown)
+    private var aggregateID = AudioObjectID(kAudioObjectUnknown)
+    private var ioProcID: AudioDeviceIOProcID?
+
+    init() {
         let (s, b) = AsyncStream<AVAudioPCMBuffer>.makeStream()
         self.stream = s
         self.builder = b
-        super.init()
     }
 
     func start() async throws {
-        let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
-        guard let display = content.displays.first else {
-            throw VoError.noDisplayForScreenCapture
+        // Global system-output tap. vo never plays audio, so there is nothing of
+        // our own to exclude from the mix.
+        let tapDescription = CATapDescription(stereoGlobalTapButExcludeProcesses: [])
+        tapDescription.uuid = UUID()
+        tapDescription.muteBehavior = .unmuted
+        tapDescription.isPrivate = true
+
+        var tap = AudioObjectID(kAudioObjectUnknown)
+        var status = AudioHardwareCreateProcessTap(tapDescription, &tap)
+        guard status == noErr else { throw CoreAudioError(code: status, op: "CreateProcessTap") }
+        self.tapID = tap
+
+        // A process tap carries no clock of its own, so it has to ride an aggregate
+        // device anchored to the current default output device.
+        let outputUID = try defaultOutputDeviceUID()
+        let aggregateUID = UUID().uuidString
+        let description: [String: Any] = [
+            kAudioAggregateDeviceNameKey: "vo-system-tap",
+            kAudioAggregateDeviceUIDKey: aggregateUID,
+            kAudioAggregateDeviceMainSubDeviceKey: outputUID,
+            kAudioAggregateDeviceIsPrivateKey: true,
+            kAudioAggregateDeviceIsStackedKey: false,
+            kAudioAggregateDeviceTapAutoStartKey: true,
+            kAudioAggregateDeviceSubDeviceListKey: [
+                [kAudioSubDeviceUIDKey: outputUID]
+            ],
+            kAudioAggregateDeviceTapListKey: [
+                [
+                    kAudioSubTapDriftCompensationKey: true,
+                    kAudioSubTapUIDKey: tapDescription.uuid.uuidString,
+                ]
+            ],
+        ]
+
+        var aggregate = AudioObjectID(kAudioObjectUnknown)
+        status = AudioHardwareCreateAggregateDevice(description as CFDictionary, &aggregate)
+        guard status == noErr else { throw CoreAudioError(code: status, op: "CreateAggregateDevice") }
+        self.aggregateID = aggregate
+
+        var asbd = try tapStreamFormat(tap)
+        guard let format = AVAudioFormat(streamDescription: &asbd) else {
+            throw VoError.noCompatibleAudioFormat
         }
-        let filter = SCContentFilter(display: display, excludingApplications: [], exceptingWindows: [])
 
-        let config = SCStreamConfiguration()
-        config.capturesAudio = true
-        config.excludesCurrentProcessAudio = true
-        config.sampleRate = 48000
-        config.channelCount = 2
-        // Video is mandatory but we make it as cheap as possible.
-        config.width = 2
-        config.height = 2
-        config.minimumFrameInterval = CMTime(value: 1, timescale: 1)
-        config.queueDepth = 6
+        let builder = self.builder
+        var procID: AudioDeviceIOProcID?
+        status = AudioDeviceCreateIOProcIDWithBlock(&procID, aggregate, nil) { _, inInputData, _, _, _ in
+            // The no-copy buffer aliases Core Audio's IO memory; downstream consumers
+            // run async and must own their data, so deep-copy before yielding.
+            guard let aliased = AVAudioPCMBuffer(pcmFormat: format, bufferListNoCopy: inInputData),
+                  let owned = aliased.copy() else { return }
+            builder.yield(owned)
+        }
+        guard status == noErr, let procID else {
+            throw CoreAudioError(code: status, op: "CreateIOProc")
+        }
+        self.ioProcID = procID
 
-        let s = SCStream(filter: filter, configuration: config, delegate: nil)
-        try s.addStreamOutput(self, type: .audio, sampleHandlerQueue: DispatchQueue(label: "vo.spk.audio"))
-        try await s.startCapture()
-        self.scStream = s
+        status = AudioDeviceStart(aggregate, procID)
+        guard status == noErr else { throw CoreAudioError(code: status, op: "DeviceStart") }
     }
 
     func stop() async {
-        if let s = scStream {
-            try? await s.stopCapture()
-            scStream = nil
+        if let procID = ioProcID, aggregateID != AudioObjectID(kAudioObjectUnknown) {
+            AudioDeviceStop(aggregateID, procID)
+            AudioDeviceDestroyIOProcID(aggregateID, procID)
+            ioProcID = nil
+        }
+        if aggregateID != AudioObjectID(kAudioObjectUnknown) {
+            AudioHardwareDestroyAggregateDevice(aggregateID)
+            aggregateID = AudioObjectID(kAudioObjectUnknown)
+        }
+        if tapID != AudioObjectID(kAudioObjectUnknown) {
+            AudioHardwareDestroyProcessTap(tapID)
+            tapID = AudioObjectID(kAudioObjectUnknown)
         }
         builder.finish()
     }
+
+    /// UID of the current default output device, used as the aggregate's main sub-device.
+    private func defaultOutputDeviceUID() throws -> String {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var deviceID = AudioObjectID(kAudioObjectUnknown)
+        var size = UInt32(MemoryLayout<AudioObjectID>.size)
+        var status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &deviceID
+        )
+        guard status == noErr else { throw CoreAudioError(code: status, op: "DefaultOutputDevice") }
+
+        address.mSelector = kAudioDevicePropertyDeviceUID
+        var cfStr: Unmanaged<CFString>?
+        size = UInt32(MemoryLayout<Unmanaged<CFString>>.size)
+        status = withUnsafeMutablePointer(to: &cfStr) {
+            AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, $0)
+        }
+        guard status == noErr, let cf = cfStr else {
+            throw CoreAudioError(code: status, op: "OutputDeviceUID")
+        }
+        return cf.takeRetainedValue() as String
+    }
+
+    /// Stream format the tap delivers, read from the tap object itself.
+    private func tapStreamFormat(_ tap: AudioObjectID) throws -> AudioStreamBasicDescription {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioTapPropertyFormat,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var asbd = AudioStreamBasicDescription()
+        var size = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+        let status = AudioObjectGetPropertyData(tap, &address, 0, nil, &size, &asbd)
+        guard status == noErr else { throw CoreAudioError(code: status, op: "TapFormat") }
+        return asbd
+    }
 }
 
-extension SpeakerCapture: SCStreamOutput {
-    func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
-        guard type == .audio else { return }
-        guard let pcm = sampleBuffer.asPCMBuffer() else { return }
-        builder.yield(pcm)
-    }
+struct CoreAudioError: Error, CustomStringConvertible {
+    let code: OSStatus
+    let op: String
+    var description: String { "CoreAudio error (\(op)): \(code)" }
 }
 
 extension AVAudioPCMBuffer {
@@ -133,58 +222,5 @@ extension AVAudioPCMBuffer {
             }
         }
         return out
-    }
-}
-
-extension CMSampleBuffer {
-    /// Materialize the sample buffer as an AVAudioPCMBuffer by copying the audio data.
-    func asPCMBuffer() -> AVAudioPCMBuffer? {
-        guard let formatDesc = CMSampleBufferGetFormatDescription(self),
-              let asbdPtr = CMAudioFormatDescriptionGetStreamBasicDescription(formatDesc) else {
-            return nil
-        }
-        var asbd = asbdPtr.pointee
-        guard let format = AVAudioFormat(streamDescription: &asbd) else { return nil }
-
-        let frameCount = AVAudioFrameCount(CMSampleBufferGetNumSamples(self))
-        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else { return nil }
-        buffer.frameLength = frameCount
-
-        let ablSize = MemoryLayout<AudioBufferList>.size
-            + MemoryLayout<AudioBuffer>.size * (Int(format.channelCount) - 1)
-        let rawPtr = UnsafeMutableRawPointer.allocate(
-            byteCount: ablSize,
-            alignment: MemoryLayout<AudioBufferList>.alignment
-        )
-        defer { rawPtr.deallocate() }
-        let ablPtr = rawPtr.bindMemory(to: AudioBufferList.self, capacity: 1)
-
-        var blockBuffer: CMBlockBuffer?
-        let status = CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(
-            self,
-            bufferListSizeNeededOut: nil,
-            bufferListOut: ablPtr,
-            bufferListSize: ablSize,
-            blockBufferAllocator: kCFAllocatorDefault,
-            blockBufferMemoryAllocator: kCFAllocatorDefault,
-            flags: kCMSampleBufferFlag_AudioBufferList_Assure16ByteAlignment,
-            blockBufferOut: &blockBuffer
-        )
-        guard status == noErr else { return nil }
-
-        // Copy from the source ABL into the freshly allocated PCM buffer. The ABL's
-        // mData pointers point into blockBuffer, and ARC is free to release it after
-        // its last use above, so pin it for the duration of the copy.
-        withExtendedLifetime(blockBuffer) {
-            let srcList = UnsafeMutableAudioBufferListPointer(ablPtr)
-            let dstList = UnsafeMutableAudioBufferListPointer(buffer.mutableAudioBufferList)
-            for i in 0..<min(srcList.count, dstList.count) {
-                let copyBytes = Int(min(srcList[i].mDataByteSize, dstList[i].mDataByteSize))
-                if let s = srcList[i].mData, let d = dstList[i].mData {
-                    memcpy(d, s, copyBytes)
-                }
-            }
-        }
-        return buffer
     }
 }

--- a/Sources/vo/Devices.swift
+++ b/Sources/vo/Devices.swift
@@ -128,9 +128,3 @@ private func queryStringProperty(_ deviceID: AudioDeviceID, selector: AudioObjec
     }
     return cf.takeRetainedValue() as String
 }
-
-private struct CoreAudioError: Error, CustomStringConvertible {
-    let code: OSStatus
-    let op: String
-    var description: String { "CoreAudio error (\(op)): \(code)" }
-}

--- a/Sources/vo/Doctor.swift
+++ b/Sources/vo/Doctor.swift
@@ -85,7 +85,7 @@ private func printDoctorText(_ r: DoctorReport) {
     info("vo cannot directly query TCC. On first run it will prompt for:")
     info("  - Microphone")
     info("  - Speech Recognition")
-    info("  - Screen Recording (used by ScreenCaptureKit for speaker channel)")
+    info("  - Audio Recording (Core Audio process tap for the speaker channel)")
     info("If launched from Terminal, those grants attach to Terminal.app.")
 
     section("Summary")

--- a/Sources/vo/Pipeline.swift
+++ b/Sources/vo/Pipeline.swift
@@ -285,7 +285,6 @@ private func convertBuffer(_ source: AVAudioPCMBuffer, to dstFormat: AVAudioForm
 enum VoError: Error, CustomStringConvertible {
     case noCompatibleAudioFormat
     case unsupportedSpeechLocale(Locale, supported: [String])
-    case noDisplayForScreenCapture
 
     var description: String {
         switch self {
@@ -307,9 +306,6 @@ enum VoError: Error, CustomStringConvertible {
             return """
             SpeechTranscriber does not support locale \(id). Run `vo --doctor` to see all supported locales.
             """
-
-        case .noDisplayForScreenCapture:
-            return "No display available for ScreenCaptureKit. Speaker capture requires at least one display."
         }
     }
 }

--- a/Sources/vo/Vo.swift
+++ b/Sources/vo/Vo.swift
@@ -20,7 +20,7 @@ struct Vo: AsyncParsableCommand {
     @Flag(name: .long, help: "Disable microphone capture")
     var noMic: Bool = false
 
-    @Flag(name: .long, help: "Disable system audio (speaker) capture via ScreenCaptureKit")
+    @Flag(name: .long, help: "Disable system audio (speaker) capture via Core Audio process tap")
     var noSpeaker: Bool = false
 
     @Flag(name: .long, help: "Apply system voice processing (echo cancellation + noise reduction) on mic input. Note: this lowers system speaker volume while active.")


### PR DESCRIPTION
## Summary

The speaker channel went through ScreenCaptureKit, which forced the Screen & System Audio Recording TCC grant even though vo only ever wanted the audio. To satisfy the API vo had to set a 2x2 dummy video, and when the grant was denied the failure surfaced as a raw `SCStream` `-3801` error that never explained the permission actually belongs to the host terminal app (Terminal, iTerm), not vo.

Core Audio process taps (macOS 14.4+) capture system audio under the lighter Audio Recording permission, so the speaker path no longer touches screen capture at all. The tap rides a private aggregate device anchored to the current default output device, and its IOProc feeds the same `AsyncStream<AVAudioPCMBuffer>` the rest of the pipeline already consumes, so nothing downstream changes.

One behavior note for reviewers. Unlike ScreenCaptureKit, a process tap does not return an error when the grant is denied; it simply yields silence with no queryable status. So this trades the explicit (but mislabeled) `-3801` error for a more appropriate permission at the cost of a clean denial signal.

## Changes

- **`Sources/vo/AudioSource.swift`** rewrites `SpeakerCapture` on `CATapDescription` + `AudioHardwareCreateProcessTap`. It builds a private aggregate device (main sub-device = default output) so the tap has a clock, reads the tap's stream format via `kAudioTapPropertyFormat`, installs an IOProc that deep-copies each buffer before yielding, and tears the tap / aggregate / IOProc down on stop. The dead `CMSampleBuffer.asPCMBuffer()` helper and the ScreenCaptureKit / CoreMedia imports are gone.
- **`Sources/vo/Pipeline.swift`** drops the now-unreachable `VoError.noDisplayForScreenCapture` and `.screenRecordingPermissionDenied` cases.
- **`Sources/vo/Devices.swift`** removes its private `CoreAudioError` so the type defined alongside the tap code is shared.
- **`Resources/Info.plist`** swaps `NSScreenCaptureUsageDescription` for `NSAudioCaptureUsageDescription`.
- **`Sources/vo/Doctor.swift`** and **`Sources/vo/Vo.swift`** update the `--doctor` permission line and `--no-speaker` help to say Audio Recording / Core Audio tap.
- **`README.md`** and **`CLAUDE.md`** describe the Audio Recording grant and the process-tap architecture instead of Screen Recording / ScreenCaptureKit.

## Test plan

- [x] `swift build` clean
- [x] `./scripts/test.sh` (8 tests, 3 suites) pass
- [x] `./scripts/build.sh` produces an ad-hoc-signed release binary with `NSAudioCaptureUsageDescription` embedded (verified the `__info_plist` section matches the source plist byte-for-byte)
- [x] `vo --doctor` reports `Audio Recording (Core Audio process tap for the speaker channel)`
- [ ] Interactive: `vo --no-mic --src en-US --dst ja-JP` while audio plays. Confirm the system-audio TCC prompt appears (Audio Recording, not Screen Recording), and after granting, speaker audio is transcribed and translated.
- [ ] Confirm no Screen Recording prompt or requirement appears anywhere in the speaker flow.