### PR TITLE
feat: resolve speech and translation models up front at startup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ injects the needed `-F` / `-rpath` flags only when that layout is detected. Unde
 - macOS 26+ (uses `SpeechTranscriber`, `SpeechAnalyzer`, `TranslationSession`, all macOS 26 only)
 - Apple Silicon (Neural Engine)
 - TCC permissions granted on first run: Microphone, Speech Recognition, and (unless `--no-speaker` is passed) Audio Recording. The speaker channel uses a Core Audio process tap, **not** ScreenCaptureKit, so it needs only the Audio Recording grant, never Screen Recording. When launched from Terminal.app, the grants attach to Terminal.app rather than `vo` itself unless `vo` is properly bundled and signed.
+- On-device models. `Pipeline.run()` resolves both before any channel starts (once, since both channels share `--src`). The speech model for `--src` downloads headlessly via `AssetInventory.downloadAndInstall()` on first run, with a one-line `Downloading speech model…` notice on **stderr** (so JSONL on stdout stays clean). The translation model for `--src → --dst` **cannot** be downloaded headlessly (the Translation framework only downloads via a UI sheet a CLI can't present), so `ensureTranslationModel` checks `LanguageAvailability.status` up front and fails fast with `VoError.translationModelNotInstalled` (install via System Settings) or `.unsupportedTranslationPair`, rather than letting every chunk surface `[translation failed]`.
 
 ## CLI surface
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Translation lines are shown in dim text under the source. Pairs are emitted in s
 - **Speech model** (`--src`): downloaded automatically on first run. `vo` prints `Downloading speech model for <locale>…` to stderr and blocks until it finishes, so the first launch takes a few extra seconds.
 - **Translation model** (`--src` → `--dst`): cannot be downloaded by `vo`. macOS only installs translation languages through a system UI, so install the pair yourself via **System Settings > General > Language & Region > Translation Languages**, then re-run. If the pair is missing, `vo` exits at startup with instructions instead of failing on every line.
 
-Run `vo --doctor` to see which speech models are installed and which translation language pairs are available.
+Run `vo --doctor` to see which speech models are installed and which translation languages are available on this device.
 
 > [!NOTE]
 > Downloading a translation language in System Settings does **not** auto-download the matching speech model, and vice versa. They are separate assets.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ Translation lines are shown in dim text under the source. Pairs are emitted in s
 - Apple Silicon (Neural Engine)
 - TCC permissions: Microphone, Speech Recognition, and Audio Recording (speaker capture is on by default; disable it with `--no-speaker`)
 
+## Models
+
+`vo` runs entirely on-device, so the speech and translation models for your languages must be present locally.
+
+- **Speech model** (`--src`): downloaded automatically on first run. `vo` prints `Downloading speech model for <locale>…` to stderr and blocks until it finishes, so the first launch takes a few extra seconds.
+- **Translation model** (`--src` → `--dst`): cannot be downloaded by `vo`. macOS only installs translation languages through a system UI, so install the pair yourself via **System Settings > General > Language & Region > Translation Languages**, then re-run. If the pair is missing, `vo` exits at startup with instructions instead of failing on every line.
+
+Run `vo --doctor` to see which speech models are installed and which translation language pairs are available.
+
+> [!NOTE]
+> Downloading a translation language in System Settings does **not** auto-download the matching speech model, and vice versa. They are separate assets.
+
 ## Build
 
 ```console

--- a/Sources/vo/Pipeline.swift
+++ b/Sources/vo/Pipeline.swift
@@ -198,8 +198,14 @@ struct Pipeline {
             let session = TranslationSession(installedSource: sourceLang, target: targetLang)
             // run() already verified the pair via ensureTranslationModel (it throws
             // otherwise), so warm the model now to keep the first chunk's translation
-            // off the lazy on-demand loading path.
-            try? await session.prepareTranslation()
+            // off the lazy on-demand loading path. A warm-up failure is non-fatal (the
+            // per-chunk translate path still surfaces real errors), but a cancellation
+            // means shutdown started, so bail instead of entering the chunk loop.
+            do {
+                try await session.prepareTranslation()
+            } catch is CancellationError {
+                return
+            } catch {}
             for await (seq, text) in chunkSeq {
                 do {
                     let response = try await session.translate(text)

--- a/Sources/vo/Pipeline.swift
+++ b/Sources/vo/Pipeline.swift
@@ -72,6 +72,16 @@ struct Pipeline {
     func run() async throws {
         let counter = SeqCounter()
 
+        // Resolve models once, before any channel starts. Both channels share the
+        // source locale, so doing this here (instead of per-channel) avoids a double
+        // download and lets us emit a single progress line. The speech asset can be
+        // fetched headlessly; the translation model cannot, so we fail fast with
+        // install instructions rather than letting every chunk surface a failure.
+        try await ensureSpeechAsset(locale: sourceLocale)
+        if let targetLocale {
+            try await ensureTranslationModel(source: sourceLocale, target: targetLocale)
+        }
+
         try await withThrowingTaskGroup(of: Void.self) { group in
             if enableMic {
                 group.addTask {
@@ -118,7 +128,6 @@ struct Pipeline {
             attributeOptions: [.audioTimeRange]
         )
         let analyzer = SpeechAnalyzer(modules: [transcriber])
-        try await ensureSpeechAsset(for: transcriber, locale: sourceLocale)
 
         guard let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: [transcriber]) else {
             throw VoError.noCompatibleAudioFormat
@@ -187,6 +196,9 @@ struct Pipeline {
         let translator: Task<Void, Never>? = willTranslate ? Task {
             guard let targetLang else { return }
             let session = TranslationSession(installedSource: sourceLang, target: targetLang)
+            // The pair is already confirmed installed in run(); warm the model now so
+            // the first chunk's translation isn't delayed by lazy on-demand loading.
+            try? await session.prepareTranslation()
             for await (seq, text) in chunkSeq {
                 do {
                     let response = try await session.translate(text)
@@ -238,7 +250,7 @@ struct Pipeline {
 
     // MARK: - Helpers
 
-    private func ensureSpeechAsset(for transcriber: SpeechTranscriber, locale: Locale) async throws {
+    private func ensureSpeechAsset(locale: Locale) async throws {
         let supportedIDs = (await SpeechTranscriber.supportedLocales).map { $0.identifier(.bcp47) }
         let isSupported = supportedIDs.contains(locale.identifier(.bcp47))
         guard isSupported else {
@@ -247,12 +259,45 @@ struct Pipeline {
 
         let installed = await SpeechTranscriber.installedLocales
         let isInstalled = installed.contains { $0.identifier(.bcp47) == locale.identifier(.bcp47) }
-        if !isInstalled {
-            if let req = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
-                try await req.downloadAndInstall()
-            }
+        guard !isInstalled else { return }
+
+        // Unlike the Translation framework, the speech asset downloads headlessly.
+        // Announce it so the first run's blocking wait doesn't look like a hang.
+        emitProgress("Downloading speech model for \(locale.identifier(.bcp47))… (first run only)")
+        let transcriber = SpeechTranscriber(
+            locale: locale,
+            transcriptionOptions: [],
+            reportingOptions: [.volatileResults, .fastResults],
+            attributeOptions: [.audioTimeRange]
+        )
+        if let req = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
+            try await req.downloadAndInstall()
         }
     }
+
+    /// Verify the translation model for this pair is installed. The Translation
+    /// framework only downloads via a UI confirmation sheet, which a CLI cannot
+    /// present, so an uninstalled pair would otherwise fail silently on every
+    /// chunk. Fail fast with install instructions instead.
+    private func ensureTranslationModel(source: Locale, target: Locale) async throws {
+        let status = await LanguageAvailability().status(from: source.language, to: target.language)
+        switch status {
+        case .installed:
+            return
+        case .supported:
+            throw VoError.translationModelNotInstalled(source: source, target: target)
+        case .unsupported:
+            throw VoError.unsupportedTranslationPair(source: source, target: target)
+        @unknown default:
+            return
+        }
+    }
+}
+
+/// Write a one-line status to stderr. Stays off stdout so it never corrupts the
+/// JSONL stream a downstream reader may be consuming.
+private func emitProgress(_ message: String) {
+    FileHandle.standardError.write(Data((message + "\n").utf8))
 }
 
 /// Convert one PCM buffer to the analyzer's preferred format. Handles sample-rate conversion.
@@ -285,11 +330,27 @@ private func convertBuffer(_ source: AVAudioPCMBuffer, to dstFormat: AVAudioForm
 enum VoError: Error, CustomStringConvertible {
     case noCompatibleAudioFormat
     case unsupportedSpeechLocale(Locale, supported: [String])
+    case translationModelNotInstalled(source: Locale, target: Locale)
+    case unsupportedTranslationPair(source: Locale, target: Locale)
 
     var description: String {
         switch self {
         case .noCompatibleAudioFormat:
             return "No audio format compatible with SpeechTranscriber is available on this device."
+
+        case .translationModelNotInstalled(let s, let t):
+            return """
+            Translation model for \(s.identifier(.bcp47)) → \(t.identifier(.bcp47)) is supported but not downloaded.
+            macOS does not allow downloading it from a CLI, so install it once via
+            System Settings > General > Language & Region > Translation Languages, then re-run.
+            (Run `vo --doctor` to list installed translation languages.)
+            """
+
+        case .unsupportedTranslationPair(let s, let t):
+            return """
+            Translation from \(s.identifier(.bcp47)) to \(t.identifier(.bcp47)) is not supported on this device.
+            Run `vo --doctor` to see available translation languages.
+            """
 
         case .unsupportedSpeechLocale(let l, let supported):
             let id = l.identifier(.bcp47)

--- a/Sources/vo/Pipeline.swift
+++ b/Sources/vo/Pipeline.swift
@@ -196,8 +196,9 @@ struct Pipeline {
         let translator: Task<Void, Never>? = willTranslate ? Task {
             guard let targetLang else { return }
             let session = TranslationSession(installedSource: sourceLang, target: targetLang)
-            // The pair is already confirmed installed in run(); warm the model now so
-            // the first chunk's translation isn't delayed by lazy on-demand loading.
+            // run() already verified the pair via ensureTranslationModel (it throws
+            // otherwise), so warm the model now to keep the first chunk's translation
+            // off the lazy on-demand loading path.
             try? await session.prepareTranslation()
             for await (seq, text) in chunkSeq {
                 do {
@@ -261,18 +262,18 @@ struct Pipeline {
         let isInstalled = installed.contains { $0.identifier(.bcp47) == locale.identifier(.bcp47) }
         guard !isInstalled else { return }
 
-        // Unlike the Translation framework, the speech asset downloads headlessly.
-        // Announce it so the first run's blocking wait doesn't look like a hang.
-        emitProgress("Downloading speech model for \(locale.identifier(.bcp47))… (first run only)")
         let transcriber = SpeechTranscriber(
             locale: locale,
             transcriptionOptions: [],
             reportingOptions: [.volatileResults, .fastResults],
             attributeOptions: [.audioTimeRange]
         )
-        if let req = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
-            try await req.downloadAndInstall()
-        }
+        guard let req = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) else { return }
+        // Unlike the Translation framework, the speech asset downloads headlessly.
+        // Announce it only once a real request exists, so the first run's blocking
+        // wait doesn't look like a hang without claiming a download that isn't happening.
+        emitProgress("Downloading speech model for \(locale.identifier(.bcp47))… (first run only)")
+        try await req.downloadAndInstall()
     }
 
     /// Verify the translation model for this pair is installed. The Translation
@@ -289,7 +290,9 @@ struct Pipeline {
         case .unsupported:
             throw VoError.unsupportedTranslationPair(source: source, target: target)
         @unknown default:
-            return
+            // A status we don't recognize is not a confirmed install, so fail fast
+            // rather than letting an unverified pair reach the per-chunk translate path.
+            throw VoError.translationModelNotInstalled(source: source, target: target)
         }
     }
 }
@@ -343,7 +346,7 @@ enum VoError: Error, CustomStringConvertible {
             Translation model for \(s.identifier(.bcp47)) → \(t.identifier(.bcp47)) is supported but not downloaded.
             macOS does not allow downloading it from a CLI, so install it once via
             System Settings > General > Language & Region > Translation Languages, then re-run.
-            (Run `vo --doctor` to list installed translation languages.)
+            (Run `vo --doctor` to see translation languages available on this device.)
             """
 
         case .unsupportedTranslationPair(let s, let t):

--- a/Sources/vo/Pipeline.swift
+++ b/Sources/vo/Pipeline.swift
@@ -349,7 +349,7 @@ enum VoError: Error, CustomStringConvertible {
 
         case .translationModelNotInstalled(let s, let t):
             return """
-            Translation model for \(s.identifier(.bcp47)) → \(t.identifier(.bcp47)) is supported but not downloaded.
+            Translation model for \(s.identifier(.bcp47)) → \(t.identifier(.bcp47)) is not installed.
             macOS does not allow downloading it from a CLI, so install it once via
             System Settings > General > Language & Region > Translation Languages, then re-run.
             (Run `vo --doctor` to see translation languages available on this device.)

--- a/Tests/voTests/VoErrorTests.swift
+++ b/Tests/voTests/VoErrorTests.swift
@@ -30,4 +30,31 @@ struct VoErrorTests {
         #expect(msg.contains("--doctor"))
         #expect(!msg.contains("regional variants"))
     }
+
+    /// A supported-but-not-downloaded translation pair names both locales and the
+    /// System Settings path the user must follow, since a CLI can't trigger the download.
+    @Test func translationModelNotInstalledNamesPairAndInstallPath() {
+        let err = VoError.translationModelNotInstalled(
+            source: Locale(identifier: "en-US"),
+            target: Locale(identifier: "ja-JP")
+        )
+        let msg = err.description
+
+        #expect(msg.contains("en-US"))
+        #expect(msg.contains("ja-JP"))
+        #expect(msg.contains("System Settings"))
+    }
+
+    /// An unsupported translation pair names both locales and points at `--doctor`.
+    @Test func unsupportedTranslationPairPointsToDoctor() {
+        let err = VoError.unsupportedTranslationPair(
+            source: Locale(identifier: "en-US"),
+            target: Locale(identifier: "xx")
+        )
+        let msg = err.description
+
+        #expect(msg.contains("en-US"))
+        #expect(msg.contains("not supported"))
+        #expect(msg.contains("--doctor"))
+    }
 }


### PR DESCRIPTION
## Summary

Both model paths failed opaquely on the first run. The speech asset downloads headlessly via `AssetInventory`, but with no output, so the first run blocked for several seconds with a blank screen and looked like a hang. The translation model is worse: the Translation framework only downloads a language pair through a UI sheet that a CLI cannot present, so an uninstalled pair let `TranslationSession` init succeed and then surfaced `[translation failed]` on every single chunk with no way to recover.

This resolves both models once in `Pipeline.run()`, before any channel starts. The two channels share `--src`, so the previous per-channel `ensureSpeechAsset` also risked a double download; hoisting it removes that race and lets us emit a single progress line.

One note for reviewers: the asymmetry is intentional and forced by the frameworks. Speech assets *can* be fetched headlessly (`AssetInventory.downloadAndInstall()`), so vo auto-downloads them. Translation assets *cannot* (no UI to present the consent sheet), so vo deliberately does not try to download them and instead fails fast with install instructions.

## Changes

- **`Sources/vo/Pipeline.swift`** — move `ensureSpeechAsset` out of `runChannel` into `run()` so it runs once for the shared `--src`. When the locale is supported but not installed, print `Downloading speech model for <locale>… (first run only)` to **stderr** (never stdout, so JSONL stays clean) before `downloadAndInstall()`.
- **`Sources/vo/Pipeline.swift`** — add `ensureTranslationModel`, called once in `run()` when `--dst` is set. It checks `LanguageAvailability.status(from:to:)` and throws `VoError.translationModelNotInstalled` (with the System Settings install path) for `.supported` or `.unsupportedTranslationPair` for `.unsupported`, replacing the per-chunk `[translation failed]` degradation.
- **`Sources/vo/Pipeline.swift`** — warm the model with `try? await session.prepareTranslation()` once per channel (the pair is already confirmed installed) so the first chunk's translation isn't delayed by lazy on-demand loading.
- **`CLAUDE.md`** — document the on-device model resolution behavior and the speech/translation download asymmetry under Runtime requirements.
- **`README.md`** — add a Models section explaining the auto-downloaded speech asset and the manually-installed translation pair, so users learn where the models come from before hitting the startup error.

## Test plan

- [x] `swift build` is clean (no warnings/errors).
- [x] `./scripts/test.sh` passes (8 tests, incl. the `VoError messages` suite).
- [ ] Manual on macOS 26 + Apple Silicon with TCC grants: the speech/translation runtime paths require hardware and grants and are not unit-tested. Verify (1) the first-run speech download notice appears on stderr, (2) `--dst` with an uninstalled translation pair exits with the install instructions, and (3) an installed pair translates as before.
