### PR TITLE
feat: stop gracefully when the audio device changes mid-session

### DIFF
--- a/Sources/vo/AudioSource.swift
+++ b/Sources/vo/AudioSource.swift
@@ -18,9 +18,12 @@ enum AudioChannel: String, Sendable, CaseIterable {
 /// Microphone capture using AVAudioEngine.
 final class MicCapture: @unchecked Sendable {
     let stream: AsyncStream<AVAudioPCMBuffer>
+    /// Invoked once if the default input device changes out from under the engine.
+    var onDeviceLost: (@Sendable () -> Void)?
     private let builder: AsyncStream<AVAudioPCMBuffer>.Continuation
     private let engine = AVAudioEngine()
     private let voiceProcessing: Bool
+    private var deviceListener: DefaultDeviceChangeListener?
 
     init(voiceProcessing: Bool = false) {
         self.voiceProcessing = voiceProcessing
@@ -54,9 +57,20 @@ final class MicCapture: @unchecked Sendable {
             builder.yield(copy)
         }
         try engine.start()
+
+        // The engine stays bound to the input device it started on. If the default
+        // input changes (new default selected, current one unplugged), the tap goes
+        // quiet with no error, so watch for the change and let the channel stop.
+        let listener = DefaultDeviceChangeListener(selector: kAudioHardwarePropertyDefaultInputDevice) { [weak self] in
+            self?.onDeviceLost?()
+        }
+        listener.start()
+        self.deviceListener = listener
     }
 
     func stop() {
+        deviceListener?.cancel()
+        deviceListener = nil
         engine.inputNode.removeTap(onBus: 0)
         engine.stop()
         builder.finish()
@@ -68,11 +82,14 @@ final class MicCapture: @unchecked Sendable {
 /// would force a screen-capture grant even though vo only ever wanted the audio.
 final class SpeakerCapture: @unchecked Sendable {
     let stream: AsyncStream<AVAudioPCMBuffer>
+    /// Invoked once if the default output device changes out from under the aggregate.
+    var onDeviceLost: (@Sendable () -> Void)?
     private let builder: AsyncStream<AVAudioPCMBuffer>.Continuation
 
     private var tapID = AudioObjectID(kAudioObjectUnknown)
     private var aggregateID = AudioObjectID(kAudioObjectUnknown)
     private var ioProcID: AudioDeviceIOProcID?
+    private var deviceListener: DefaultDeviceChangeListener?
     // Runs the IOProc off Core Audio's real-time IO thread: the block deep-copies
     // and yields into an AsyncStream, neither of which is safe on the RT thread.
     private let ioQueue = DispatchQueue(label: "vo.spk.audio")
@@ -156,9 +173,20 @@ final class SpeakerCapture: @unchecked Sendable {
 
         status = AudioDeviceStart(aggregate, procID)
         guard status == noErr else { throw CoreAudioError(code: status, op: "DeviceStart") }
+
+        // The aggregate stays anchored to the output device it was built on. If the
+        // default output changes, the tap keeps reading a stale (or vanished) device
+        // with no error, so watch for the change and let the channel stop.
+        let listener = DefaultDeviceChangeListener(selector: kAudioHardwarePropertyDefaultOutputDevice) { [weak self] in
+            self?.onDeviceLost?()
+        }
+        listener.start()
+        self.deviceListener = listener
     }
 
     func stop() async {
+        deviceListener?.cancel()
+        deviceListener = nil
         if let procID = ioProcID, aggregateID != AudioObjectID(kAudioObjectUnknown) {
             AudioDeviceStop(aggregateID, procID)
             AudioDeviceDestroyIOProcID(aggregateID, procID)
@@ -213,6 +241,53 @@ final class SpeakerCapture: @unchecked Sendable {
         let status = AudioObjectGetPropertyData(tap, &address, 0, nil, &size, &asbd)
         guard status == noErr else { throw CoreAudioError(code: status, op: "TapFormat") }
         return asbd
+    }
+}
+
+/// Fires `onChange` once when the system default input or output device changes, so a
+/// capture bound to the old device can stop instead of going silently dead. The OS
+/// listener block is installed on the main queue and removed on `cancel()`.
+final class DefaultDeviceChangeListener: @unchecked Sendable {
+    private let selector: AudioObjectPropertySelector
+    private let onChange: @Sendable () -> Void
+    private var block: AudioObjectPropertyListenerBlock?
+    private var fired = false
+
+    init(selector: AudioObjectPropertySelector, onChange: @escaping @Sendable () -> Void) {
+        self.selector = selector
+        self.onChange = onChange
+    }
+
+    private var address: AudioObjectPropertyAddress {
+        AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+    }
+
+    func start() {
+        var addr = address
+        let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+            // Coalesce to a single shutdown: the default-device property can fire more
+            // than once for one switch, and downstream stopAll is idempotent anyway.
+            guard let self, !self.fired else { return }
+            self.fired = true
+            self.onChange()
+        }
+        self.block = block
+        AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject), &addr, DispatchQueue.main, block
+        )
+    }
+
+    func cancel() {
+        guard let block else { return }
+        var addr = address
+        AudioObjectRemovePropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject), &addr, DispatchQueue.main, block
+        )
+        self.block = nil
     }
 }
 

--- a/Sources/vo/Pipeline.swift
+++ b/Sources/vo/Pipeline.swift
@@ -106,6 +106,20 @@ struct Pipeline {
         await stops.stopAll()
     }
 
+    /// Build the callback a capture runs when its audio device changes mid-session.
+    /// vo does not follow the new device; it announces why on stderr and then runs the
+    /// same graceful shutdown as Ctrl-C. stopAll finishes every channel's stream, so
+    /// run() returns and the natural completion path saves the transcript and prints
+    /// the summary. The user restarts vo to pick up the new device.
+    private func deviceLostHandler(for channel: AudioChannel) -> @Sendable () -> Void {
+        let stops = self.stops
+        let what = channel == .mic ? "microphone input device" : "system audio output device"
+        return {
+            emitProgress("vo: the \(what) changed or disconnected. Stopping. Restart vo to use the new device.")
+            Task { await stops.stopAll() }
+        }
+    }
+
     // MARK: - Per-channel
 
     private func runChannel(
@@ -147,11 +161,13 @@ struct Pipeline {
         switch channel {
         case .mic:
             let cap = MicCapture(voiceProcessing: voiceProcessing)
+            cap.onDeviceLost = deviceLostHandler(for: .mic)
             try cap.start()
             audioStream = cap.stream
             stopper = { cap.stop() }
         case .speaker:
             let cap = SpeakerCapture()
+            cap.onDeviceLost = deviceLostHandler(for: .speaker)
             try await cap.start()
             audioStream = cap.stream
             stopper = { await cap.stop() }


### PR DESCRIPTION
## Summary

Both capture paths bind to a device at startup and never rebind. The mic [`AVAudioEngine`](https://developer.apple.com/documentation/avfaudio/avaudioengine) stays on the input device it started on, and the speaker [Core Audio tap](https://developer.apple.com/documentation/coreaudio/capturing-system-audio-with-core-audio-taps) rides an aggregate anchored to the output device it was built on. So when the default input or output device changes mid-session (the user selects a new default, or unplugs the current one), the stream just goes quiet **with no error**. The channel is silently dead while vo still looks like it is listening, and the only recovery is for the user to notice the silence and restart.

This makes vo stop on its own when that happens, with a clear reason, instead of running as a zombie.

A couple of notes for reviewers on what this deliberately does **not** do:

- **It does not follow the new device.** Rebinding would mean tearing down and rebuilding the engine / aggregate device and re-warming the analyzer, which is more surface than this is worth for now. Stopping with a "restart vo" message is the chosen MVP. Seamless follow can come later.
- **It does not detect silence by amplitude.** vo is a passive listener, so a genuinely quiet room is indistinguishable from a dead device at the sample level. An amplitude-based silence timeout would exit during normal pauses. The signal used here is the precise OS one: a [Core Audio property listener](https://developer.apple.com/documentation/coreaudio/audioobjectaddpropertylistenerblock) on the default-device selector, which fires only on an actual default-device change.
- **It stops the whole process, not just the affected channel.** Even in a two-channel run, losing one device ends the session. This keeps the behavior and the message simple; per-channel degradation can come later if wanted.

Known gap: a same-device reconfiguration (e.g. a sample-rate change) or unplugging a **non-default** device is not caught by the default-device listener. Those still fall back to the user pressing Ctrl-C.

## Changes

- **`Sources/vo/AudioSource.swift`** — add `DefaultDeviceChangeListener`, a small wrapper over `AudioObjectAddPropertyListenerBlock` that fires a one-shot callback (the property can fire more than once per switch) on the main queue and removes itself on `cancel()`. `MicCapture` watches `kAudioHardwarePropertyDefaultInputDevice` and `SpeakerCapture` watches `kAudioHardwarePropertyDefaultOutputDevice`; each exposes an `onDeviceLost` callback and tears the listener down in `stop()` (before destroying the aggregate, on the speaker side).
- **`Sources/vo/Pipeline.swift`** — `runChannel` wires each capture's `onDeviceLost` to `deviceLostHandler(for:)`, which prints `vo: the <device> changed or disconnected. Stopping. Restart vo to use the new device.` to **stderr** (so JSONL on stdout stays clean) and then calls `stops.stopAll()`. That finishes every channel's stream, so `run()` returns through the existing natural-completion path and the transcript save prompt + summary run exactly as on Ctrl-C. No new exit path.

## Test plan

- [x] `swift build` clean.
- [x] `./scripts/test.sh` passes (12 tests, unchanged — this path needs TCC + hardware and is out of unit-test scope, consistent with the rest of the audio code).
- [ ] Manual on macOS 26 + Apple Silicon: while `vo --src en-US` runs, switch the default input device (or unplug it) and confirm vo prints the mic message and proceeds to the save prompt rather than hanging.
- [ ] Manual: while `vo --no-mic --src en-US` runs with audio playing, switch the default output device (or disconnect it) and confirm vo prints the speaker message and stops cleanly.
- [ ] Confirm a normal `Ctrl-C` still behaves as before (no double finalize, save prompt once).