### PR TITLE
feat: show the capture device for each channel in the startup banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ $ vo                                  # Listen to mic + speaker, transcribe only
 $ vo --src en-US --dst ja-JP          # Transcribe and translate
 $ vo --no-speaker                     # Mic only
 $ vo --no-mic --src en-US --dst ja-JP # Speaker only, with translation
+$ vo --select-device                  # Pick & pin the mic / speaker at startup
 $ vo --json | jq                      # JSONL output for piping
 $ vo --doctor                         # Environment diagnostics
 ```
@@ -85,6 +86,14 @@ Translation lines are shown in dim text under the source. Pairs are emitted in s
 
 `src.confidence` reports the transcription's per-chunk confidence, with `mean` weighted across the chunk and `min` taken from its least-confident run. This is acoustic confidence rather than a correctness guarantee, so a low `min` is a useful cue that a chunk is worth re-listening to. There is no counterpart for `dst`, because the translation framework exposes no quality score. The object is omitted only when no confidence value is available.
 
+### Device selection
+
+By default `vo` captures from the system default microphone and output device and follows them. If the default input or output changes mid-session (you switch output, or plug in headphones), `vo` rebuilds that channel on the new default and keeps going instead of stopping.
+
+`--select-device` instead prompts you to pick the mic and speaker device at startup and pins the choice, so a later system-default change is ignored and the chosen device stays in use. The picker writes its menu to stderr and reads your choice from stdin, so `vo --select-device --json > out.jsonl` keeps stdout pure JSONL while you select. It needs a terminal for stdin and stderr, so it errors out when stdin is piped.
+
+A pinned device that is unplugged mid-session goes quiet rather than rebuilding, so re-run `vo` to pick a new one. The startup banner shows which device each channel is using, with a `(default)` or `[pinned]` note.
+
 ### Voice processing
 
 `--voice-processing` turns on Apple's voice IO (echo cancellation + noise reduction + AGC). Useful when running mic + speaker on the same physical device without headphones. The trade-off is that the macOS audio session enters communication mode, which lowers system speaker volume while `vo` is running. Off by default.
@@ -97,6 +106,7 @@ Translation lines are shown in dim text under the source. Pairs are emitted in s
 | `--dst` | (none) | Target locale. Omit to skip translation |
 | `--no-mic` | (off, mic on) | Disable microphone capture |
 | `--no-speaker` | (off, speaker on) | Disable system audio capture |
+| `--select-device` | off | Interactively pick (and pin) the mic / speaker device at startup. Needs a terminal |
 | `--voice-processing` | off | Apply echo cancellation on mic input |
 | `--json` | | Force JSONL output |
 | `--transcript <path>` | (none; prompts at exit in TTY) | Stream finalized chunks as JSONL to `<path>` incrementally. Skips the interactive save prompt |

--- a/README.md
+++ b/README.md
@@ -57,13 +57,17 @@ $ vo --doctor                         # Environment diagnostics
 ### TTY output
 
 ```
-vo 0.1.0 — listening on mic + speaker (en-US → ja-JP)
+vo 0.6.0 — listening on mic + speaker (en-US → ja-JP)
+  mic      MacBook Pro Microphone  (default)
+  speaker  External Headphones     [pinned]
 
 08:34:56 [mic]  How are you doing?
                 元気ですか？
 08:34:58 [spk]  I'm fine, thanks.
                 元気だよ、ありがとう。
 ```
+
+Under the header, one line per active channel shows the device it is capturing from. A dim note reads `(default)` when the channel follows the system default device (and rebinds automatically if that default changes), or `[pinned]` when `--select-device` locked the channel to a specific device.
 
 The `[mic]` / `[spk]` label is shown only when both channels are active; with `--no-mic` or `--no-speaker` it is omitted and the timestamp alone marks each line. The timestamp shares the channel's tint (amber for mic, teal for speaker), so a single glance tells you which side just spoke.
 

--- a/Sources/vo/AudioSource.swift
+++ b/Sources/vo/AudioSource.swift
@@ -21,6 +21,15 @@ enum AudioChannel: String, Sendable, CaseIterable {
         case .speaker: return "system audio output device"
         }
     }
+
+    /// 256-color palette tint for this channel's TTY output (Terminal.app safe).
+    /// mic = amber, speaker = teal. Shared by the live renderer and the startup banner.
+    var tint256: Int {
+        switch self {
+        case .mic:     return 130
+        case .speaker: return 24
+        }
+    }
 }
 
 /// Microphone capture using AVAudioEngine.

--- a/Sources/vo/DeviceSelection.swift
+++ b/Sources/vo/DeviceSelection.swift
@@ -19,6 +19,43 @@ func canSelectDevicesInteractively() -> Bool {
     return isatty(fileno(stdin)) != 0 && isatty(fileno(stderr)) != 0
 }
 
+/// A capture device shown in the startup banner: its name and whether it is pinned
+/// (`--select-device`) or the system default the channel follows.
+struct CaptureDeviceLabel {
+    let name: String
+    let pinned: Bool
+}
+
+/// Resolve the devices the enabled channels will capture from at startup, for the
+/// banner. A pinned channel resolves to the chosen device; otherwise the system default.
+/// A label is nil when the channel is disabled, enumeration fails, or the device is no
+/// longer present.
+func resolvedCaptureDeviceLabels(mic: Bool, speaker: Bool, selected: SelectedDevices) -> (mic: CaptureDeviceLabel?, speaker: CaptureDeviceLabel?) {
+    var micLabel: CaptureDeviceLabel?
+    var speakerLabel: CaptureDeviceLabel?
+    if mic {
+        let inputs = (try? collectInputDevices()) ?? []
+        if let id = selected.micDeviceID {
+            if let name = inputs.first(where: { $0.id == UInt32(id) })?.name {
+                micLabel = CaptureDeviceLabel(name: name, pinned: true)
+            }
+        } else if let name = inputs.first(where: { $0.isDefault })?.name {
+            micLabel = CaptureDeviceLabel(name: name, pinned: false)
+        }
+    }
+    if speaker {
+        let outputs = (try? collectOutputDevices()) ?? []
+        if let uid = selected.speakerDeviceUID {
+            if let name = outputs.first(where: { $0.uid == uid })?.name {
+                speakerLabel = CaptureDeviceLabel(name: name, pinned: true)
+            }
+        } else if let name = outputs.first(where: { $0.isDefault })?.name {
+            speakerLabel = CaptureDeviceLabel(name: name, pinned: false)
+        }
+    }
+    return (micLabel, speakerLabel)
+}
+
 /// Prompt the user to pick the mic / speaker device for the enabled channels.
 /// Caller must ensure `canSelectDevicesInteractively()`. A picked device is pinned,
 /// so subsequent system-default changes are ignored for that channel.

--- a/Sources/vo/DeviceSelection.swift
+++ b/Sources/vo/DeviceSelection.swift
@@ -28,30 +28,35 @@ struct CaptureDeviceLabel {
 
 /// Resolve the devices the enabled channels will capture from at startup, for the
 /// banner. A pinned channel resolves to the chosen device; otherwise the system default.
-/// A label is nil when the channel is disabled, enumeration fails, or the device is no
-/// longer present.
+/// An enabled channel always yields a label so the banner shows one line per active
+/// channel: when resolution fails (enumeration error, or a pinned device that vanished)
+/// the name falls back to a placeholder, which is more honest than omitting the line.
+/// A label is nil only for a disabled channel.
 func resolvedCaptureDeviceLabels(mic: Bool, speaker: Bool, selected: SelectedDevices) -> (mic: CaptureDeviceLabel?, speaker: CaptureDeviceLabel?) {
+    let unavailable = "(device unavailable)"
     var micLabel: CaptureDeviceLabel?
     var speakerLabel: CaptureDeviceLabel?
     if mic {
         let inputs = (try? collectInputDevices()) ?? []
+        let pinned = selected.micDeviceID != nil
+        let name: String?
         if let id = selected.micDeviceID {
-            if let name = inputs.first(where: { $0.id == UInt32(id) })?.name {
-                micLabel = CaptureDeviceLabel(name: name, pinned: true)
-            }
-        } else if let name = inputs.first(where: { $0.isDefault })?.name {
-            micLabel = CaptureDeviceLabel(name: name, pinned: false)
+            name = inputs.first(where: { $0.id == UInt32(id) })?.name
+        } else {
+            name = inputs.first(where: { $0.isDefault })?.name
         }
+        micLabel = CaptureDeviceLabel(name: name ?? unavailable, pinned: pinned)
     }
     if speaker {
         let outputs = (try? collectOutputDevices()) ?? []
+        let pinned = selected.speakerDeviceUID != nil
+        let name: String?
         if let uid = selected.speakerDeviceUID {
-            if let name = outputs.first(where: { $0.uid == uid })?.name {
-                speakerLabel = CaptureDeviceLabel(name: name, pinned: true)
-            }
-        } else if let name = outputs.first(where: { $0.isDefault })?.name {
-            speakerLabel = CaptureDeviceLabel(name: name, pinned: false)
+            name = outputs.first(where: { $0.uid == uid })?.name
+        } else {
+            name = outputs.first(where: { $0.isDefault })?.name
         }
+        speakerLabel = CaptureDeviceLabel(name: name ?? unavailable, pinned: pinned)
     }
     return (micLabel, speakerLabel)
 }

--- a/Sources/vo/Listen.swift
+++ b/Sources/vo/Listen.swift
@@ -90,7 +90,15 @@ func runListen(
 
     let startedAt = Date()
     if isTTY {
-        printBanner(sourceLocale: sourceLocale, targetLocale: targetLocale, mic: mic, speaker: speaker)
+        let deviceLabels = resolvedCaptureDeviceLabels(mic: mic, speaker: speaker, selected: selectedDevices)
+        printBanner(
+            sourceLocale: sourceLocale,
+            targetLocale: targetLocale,
+            mic: mic,
+            speaker: speaker,
+            micDevice: deviceLabels.mic,
+            speakerDevice: deviceLabels.speaker
+        )
     }
 
     // pipeline.cancel() lets pipeline.run() below return, so after SIGINT the natural
@@ -190,7 +198,14 @@ private func finalizeSession(
 
 // MARK: - Banner / Summary
 
-private func printBanner(sourceLocale: Locale, targetLocale: Locale?, mic: Bool, speaker: Bool) {
+private func printBanner(
+    sourceLocale: Locale,
+    targetLocale: Locale?,
+    mic: Bool,
+    speaker: Bool,
+    micDevice: CaptureDeviceLabel?,
+    speakerDevice: CaptureDeviceLabel?
+) {
     let channels = [mic ? "mic" : nil, speaker ? "speaker" : nil]
         .compactMap { $0 }
         .joined(separator: " + ")
@@ -202,7 +217,27 @@ private func printBanner(sourceLocale: Locale, targetLocale: Locale?, mic: Bool,
     }
     let version = Vo.configuration.version
     print("vo \(version) — listening on \(channels) (\(langs))")
+
+    // Show which device each active channel is capturing from at startup. The channel
+    // label uses the channel's tint (matching the live output); the pinned/default note
+    // is dim so it reads as metadata. The label column aligns to "speaker" when both
+    // channels are shown.
+    let labelWidth = (mic && speaker) ? "speaker".count : 0
+    func deviceLine(_ channel: AudioChannel, _ device: CaptureDeviceLabel) {
+        let label = (channel == .mic) ? "mic" : "speaker"
+        let padded = label.padding(toLength: max(labelWidth, label.count), withPad: " ", startingAt: 0)
+        let note = device.pinned ? "[pinned]" : "(default)"
+        print("  \(ansi256(channel.tint256, padded))  \(device.name) \(ansi256(244, note))")
+    }
+    if mic, let micDevice { deviceLine(.mic, micDevice) }
+    if speaker, let speakerDevice { deviceLine(.speaker, speakerDevice) }
+
     print("")
+}
+
+/// Wrap a string in a 256-color foreground SGR escape. Matches the renderer's palette.
+private func ansi256(_ code: Int, _ s: String) -> String {
+    "\u{001B}[38;5;\(code)m\(s)\u{001B}[0m"
 }
 
 private func printSummary(count: Int, duration: TimeInterval) {

--- a/Sources/vo/Renderer.swift
+++ b/Sources/vo/Renderer.swift
@@ -237,10 +237,7 @@ actor StreamRenderer: Renderer {
     /// 256-color palette code for the given channel. Shared by the timestamp and
     /// the [mic]/[spk] label so the eye reads both as the same channel.
     private func channelColor(_ channel: AudioChannel) -> Int {
-        switch channel {
-        case .mic:     return 130
-        case .speaker: return 24
-        }
+        channel.tint256
     }
 
     private func ttyTimestamp(_ date: Date, channel: AudioChannel) -> String {


### PR DESCRIPTION
## Summary

The startup banner reported which channels and locales were active, but not which physical devices `vo` had actually grabbed. Now that `--select-device` (#23) can pin a device and the default-follow path (#24) picks the current system default, a user could not tell at a glance whether the intended mic or speaker was really in use. This adds one line per active channel showing the resolved device.

## Changes

- New `AudioChannel.tint256` centralizes the per-channel tint (amber for mic, teal for speaker) that previously lived only in `StreamRenderer.channelColor`, so the renderer and the banner share one source (separate `refactor:` commit).
- `resolvedCaptureDeviceLabels(...)` resolves, per enabled channel, the device `vo` will capture from: the pinned device when `--select-device` chose one, otherwise the current system default.
- The banner prints a line per active channel with the device name, the channel label tinted to match the live output, and a dim note: `(default)` when the channel follows the system default, `[pinned]` when `--select-device` locked it.

Example:

```
vo 0.6.0 — listening on mic + speaker (en-US → ja-JP)
  mic      MacBook Proのマイク  (default)
  speaker  External Headphones  [pinned]
```

## Test plan

- [x] `swift build` clean
- [x] `./scripts/test.sh` (20 tests, 4 suites) pass
- [x] Built the signed binary via `scripts/build.sh` for manual banner inspection
- [ ] Visual check on a real TTY: `(default)` vs `[pinned]` note, channel tints, and label alignment with one vs both channels. The banner is TTY-only, so `vo --json` / piped runs keep stdout as pure JSONL (no banner).