### PR TITLE
docs: add a Troubleshooting section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,22 @@ Run `vo --doctor` to see which speech models are installed and which translation
 > [!NOTE]
 > Downloading a translation language in System Settings does **not** auto-download the matching speech model, and vice versa. They are separate assets.
 
+## Troubleshooting
+
+Run `vo --doctor` first. It reports the macOS version, which speech models are installed, the available translation pairs, and the audio input devices, and most setup problems surface there.
+
+**Nothing is transcribed.** Check the TCC permissions. `vo` needs Microphone, Speech Recognition, and (unless `--no-speaker`) Audio Recording. If you denied any, enable them for the `vo` entry under System Settings > Privacy & Security, then restart `vo`. Confirm you are running the signed binary too: a plain `swift build` binary has no embedded usage descriptions, so macOS kills it the moment it touches the mic. Install via Homebrew or build with `scripts/build.sh`. Finally, make sure `--src` matches the spoken language; on the first run for a locale `vo` blocks while it downloads the speech model (a `Downloading speech model…` line on stderr).
+
+**The speaker side transcribes nothing while the mic works.** Look at the startup banner. The `speaker` line names the output device `vo` is capturing from, and `vo` only hears audio that actually plays through that device. If an app (a meeting client, for instance) is set to output to a different device than the one shown, its audio never reaches `vo`. Point the app's output at the same device, or pin the right one with `--select-device`. Restarting `vo` alone does not help when the system default never changed, because `vo` re-reads that same default on each launch.
+
+**A device disappears mid-session and that channel goes quiet.** An unpinned channel follows the system default and rebuilds on the new one automatically. A channel pinned with `--select-device` does not follow, so an unplugged pinned device stays silent. Re-run `vo` to pick another.
+
+**The mic keeps re-transcribing what the speakers play.** That is acoustic feedback between the speaker and the mic. Use headphones, drop one side with `--no-mic` / `--no-speaker`, or enable `--voice-processing` (echo cancellation, at the cost of lower system volume).
+
+**Output is JSONL when you expected the live view, or the reverse.** `vo` prints the ANSI live view only when STDOUT is a TTY and emits JSONL otherwise, so piping or redirecting switches it to JSONL. Pass `--json` to force JSONL explicitly. The startup banner and the per-channel device lines appear only in the TTY view.
+
+**Translation shows `[translation failed]` or never appears.** The translation model for the pair is not installed. Install it via System Settings > General > Language & Region > Translation Languages (see Models), then re-run. Transcription itself works without `--dst`.
+
 ## Build
 
 ```console

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ A pinned device that is unplugged mid-session goes quiet rather than rebuilding,
 | `--transcript <path>` | (none; prompts at exit in TTY) | Stream finalized chunks as JSONL to `<path>` incrementally. Skips the interactive save prompt |
 | `--doctor` | | Print full environment diagnostics and exit |
 
-`vo --doctor` lists supported locales, installed speech models, available translation language pairs, and audio input devices. Run it first if something behaves unexpectedly.
+`vo --doctor` lists supported locales, installed speech models, available translation languages, and audio input devices. Run it first if something behaves unexpectedly.
 
 ## Requirements
 
@@ -143,7 +143,7 @@ Run `vo --doctor` to see which speech models are installed and which translation
 
 ## Troubleshooting
 
-Run `vo --doctor` first. It reports the macOS version, which speech models are installed, the available translation pairs, and the audio input devices, and most setup problems surface there.
+Run `vo --doctor` first. It reports the macOS version, which speech models are installed, the available translation languages, and the audio input devices, and most setup problems surface there.
 
 **Nothing is transcribed.** Check the TCC permissions. `vo` needs Microphone, Speech Recognition, and (unless `--no-speaker`) Audio Recording. If you denied any, enable them under System Settings > Privacy & Security, then restart `vo`. Also confirm the grants reached `vo` itself. The signed `scripts/build.sh` and Homebrew binaries claim `vo`'s own TCC identity, so the grants attach to the `vo` entry; a plain `swift build` binary has no embedded usage descriptions and runs under the launching terminal's identity instead, so its grants attach to your terminal app, which is easy to overlook. Prefer the signed binary. Finally, make sure `--src` matches the spoken language; on the first run for a locale `vo` blocks while it downloads the speech model (a `Downloading speech model…` line on stderr).
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Run `vo --doctor` to see which speech models are installed and which translation
 
 Run `vo --doctor` first. It reports the macOS version, which speech models are installed, the available translation pairs, and the audio input devices, and most setup problems surface there.
 
-**Nothing is transcribed.** Check the TCC permissions. `vo` needs Microphone, Speech Recognition, and (unless `--no-speaker`) Audio Recording. If you denied any, enable them for the `vo` entry under System Settings > Privacy & Security, then restart `vo`. Confirm you are running the signed binary too: a plain `swift build` binary has no embedded usage descriptions, so macOS kills it the moment it touches the mic. Install via Homebrew or build with `scripts/build.sh`. Finally, make sure `--src` matches the spoken language; on the first run for a locale `vo` blocks while it downloads the speech model (a `Downloading speech model…` line on stderr).
+**Nothing is transcribed.** Check the TCC permissions. `vo` needs Microphone, Speech Recognition, and (unless `--no-speaker`) Audio Recording. If you denied any, enable them under System Settings > Privacy & Security, then restart `vo`. Also confirm the grants reached `vo` itself. The signed `scripts/build.sh` and Homebrew binaries claim `vo`'s own TCC identity, so the grants attach to the `vo` entry; a plain `swift build` binary has no embedded usage descriptions and runs under the launching terminal's identity instead, so its grants attach to your terminal app, which is easy to overlook. Prefer the signed binary. Finally, make sure `--src` matches the spoken language; on the first run for a locale `vo` blocks while it downloads the speech model (a `Downloading speech model…` line on stderr).
 
 **The speaker side transcribes nothing while the mic works.** Look at the startup banner. The `speaker` line names the output device `vo` is capturing from, and `vo` only hears audio that actually plays through that device. If an app (a meeting client, for instance) is set to output to a different device than the one shown, its audio never reaches `vo`. Point the app's output at the same device, or pin the right one with `--select-device`. Restarting `vo` alone does not help when the system default never changed, because `vo` re-reads that same default on each launch.
 
@@ -155,7 +155,7 @@ Run `vo --doctor` first. It reports the macOS version, which speech models are i
 
 **Output is JSONL when you expected the live view, or the reverse.** `vo` prints the ANSI live view only when STDOUT is a TTY and emits JSONL otherwise, so piping or redirecting switches it to JSONL. Pass `--json` to force JSONL explicitly. The startup banner and the per-channel device lines appear only in the TTY view.
 
-**Translation shows `[translation failed]` or never appears.** The translation model for the pair is not installed. Install it via System Settings > General > Language & Region > Translation Languages (see Models), then re-run. Transcription itself works without `--dst`.
+**Translation is missing or shows `[translation failed]`.** A missing or unsupported `--src → --dst` model is caught at startup, where `vo` exits with install instructions rather than running. Install the pair via System Settings > General > Language & Region > Translation Languages (see Models), then re-run. A `[translation failed: <error>]` line is a different case. It is a runtime failure of that one chunk's translation, with the cause in the message, while the rest of the session keeps going. Transcription itself works without `--dst`.
 
 ## Build
 


### PR DESCRIPTION
## Summary

The README covered installing and running `vo` but had no single place to look when transcription does not appear. The most common cause is easy to miss. The speaker channel captures whichever output device `vo` is anchored to, so audio that an app routes elsewhere is never heard, and restarting does not help because `vo` re-reads the same system default on each launch. Other dead ends (denied TCC grants, running the unsigned debug binary, a mismatched `--src` or missing speech model, an uninstalled translation model) also surface as "nothing happens", so this collects them in one place for self-diagnosis.

## Changes

- Add a `## Troubleshooting` section between Models and Build, leading with `vo --doctor` as the first check.
- Walk the common symptoms one by one, covering nothing transcribed (permissions, the unsigned debug binary, a mismatched `--src` or missing speech model), the speaker side silent while the mic works (an app routing audio to a device other than the one the startup banner shows, fixed by matching it or pinning with `--select-device`), a device disappearing mid-session (unpinned follows the default, pinned does not), mic/speaker acoustic feedback, the TTY-vs-JSONL output switch, and an uninstalled translation model.