### PR TITLE
refactor: unify Core Audio property-read boilerplate into shared helpers

### DIFF
--- a/Sources/vo/AudioSource.swift
+++ b/Sources/vo/AudioSource.swift
@@ -293,41 +293,29 @@ final class SpeakerCapture: @unchecked Sendable {
 
     /// UID of the current default output device, used as the aggregate's main sub-device.
     private func defaultOutputDeviceUID() throws -> String {
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
         var deviceID = AudioObjectID(kAudioObjectUnknown)
-        var size = UInt32(MemoryLayout<AudioObjectID>.size)
-        var status = AudioObjectGetPropertyData(
-            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &deviceID
+        try audioObjectProperty(
+            AudioObjectID(kAudioObjectSystemObject),
+            globalPropertyAddress(kAudioHardwarePropertyDefaultOutputDevice),
+            into: &deviceID,
+            op: "DefaultOutputDevice"
         )
-        guard status == noErr else { throw CoreAudioError(code: status, op: "DefaultOutputDevice") }
-
-        address.mSelector = kAudioDevicePropertyDeviceUID
-        var cfStr: Unmanaged<CFString>?
-        size = UInt32(MemoryLayout<Unmanaged<CFString>>.size)
-        status = withUnsafeMutablePointer(to: &cfStr) {
-            AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, $0)
-        }
-        guard status == noErr, let cf = cfStr else {
-            throw CoreAudioError(code: status, op: "OutputDeviceUID")
-        }
-        return cf.takeRetainedValue() as String
+        return try audioObjectString(
+            deviceID,
+            globalPropertyAddress(kAudioDevicePropertyDeviceUID),
+            op: "OutputDeviceUID"
+        )
     }
 
     /// Stream format the tap delivers, read from the tap object itself.
     private func tapStreamFormat(_ tap: AudioObjectID) throws -> AudioStreamBasicDescription {
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioTapPropertyFormat,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
         var asbd = AudioStreamBasicDescription()
-        var size = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
-        let status = AudioObjectGetPropertyData(tap, &address, 0, nil, &size, &asbd)
-        guard status == noErr else { throw CoreAudioError(code: status, op: "TapFormat") }
+        try audioObjectProperty(
+            tap,
+            globalPropertyAddress(kAudioTapPropertyFormat),
+            into: &asbd,
+            op: "TapFormat"
+        )
         return asbd
     }
 }

--- a/Sources/vo/CoreAudio+Property.swift
+++ b/Sources/vo/CoreAudio+Property.swift
@@ -1,0 +1,45 @@
+import CoreAudio
+
+/// Read a fixed-size Core Audio property into `value`. The caller owns the `op` label so the
+/// surfaced `CoreAudioError` keeps the same wording each existing call site produced.
+func audioObjectProperty<T>(
+    _ objectID: AudioObjectID,
+    _ address: AudioObjectPropertyAddress,
+    into value: inout T,
+    op: String
+) throws {
+    var address = address
+    var size = UInt32(MemoryLayout<T>.size)
+    let status = withUnsafeMutablePointer(to: &value) { ptr in
+        AudioObjectGetPropertyData(objectID, &address, 0, nil, &size, ptr)
+    }
+    guard status == noErr else { throw CoreAudioError(code: status, op: op) }
+}
+
+/// Read a CFString-typed Core Audio property. The framework hands back a +1 retained CFString,
+/// so `takeRetainedValue()` (not `takeUnretainedValue()`) balances the reference.
+func audioObjectString(
+    _ objectID: AudioObjectID,
+    _ address: AudioObjectPropertyAddress,
+    op: String
+) throws -> String {
+    var address = address
+    var cfStr: Unmanaged<CFString>?
+    var size = UInt32(MemoryLayout<Unmanaged<CFString>>.size)
+    let status = withUnsafeMutablePointer(to: &cfStr) { ptr in
+        AudioObjectGetPropertyData(objectID, &address, 0, nil, &size, ptr)
+    }
+    guard status == noErr, let cf = cfStr else {
+        throw CoreAudioError(code: status, op: op)
+    }
+    return cf.takeRetainedValue() as String
+}
+
+/// Build a global-scope, main-element property address for `selector`.
+func globalPropertyAddress(_ selector: AudioObjectPropertySelector) -> AudioObjectPropertyAddress {
+    AudioObjectPropertyAddress(
+        mSelector: selector,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+}

--- a/Sources/vo/Devices.swift
+++ b/Sources/vo/Devices.swift
@@ -56,22 +56,13 @@ private func collectDevices(_ direction: AudioDirection) throws -> [AudioDeviceI
 // MARK: - Core Audio enumeration helpers
 
 private func queryDefaultDevice(selector: AudioObjectPropertySelector) throws -> AudioDeviceID {
-    var address = AudioObjectPropertyAddress(
-        mSelector: selector,
-        mScope: kAudioObjectPropertyScopeGlobal,
-        mElement: kAudioObjectPropertyElementMain
-    )
     var deviceID: AudioDeviceID = 0
-    var size = UInt32(MemoryLayout<AudioDeviceID>.size)
-    let status = AudioObjectGetPropertyData(
+    try audioObjectProperty(
         AudioObjectID(kAudioObjectSystemObject),
-        &address,
-        0,
-        nil,
-        &size,
-        &deviceID
+        globalPropertyAddress(selector),
+        into: &deviceID,
+        op: "DefaultDevice"
     )
-    guard status == noErr else { throw CoreAudioError(code: status, op: "DefaultDevice") }
     return deviceID
 }
 
@@ -136,18 +127,5 @@ private func queryChannelCount(_ deviceID: AudioDeviceID, scope: AudioObjectProp
 }
 
 private func queryStringProperty(_ deviceID: AudioDeviceID, selector: AudioObjectPropertySelector) throws -> String {
-    var address = AudioObjectPropertyAddress(
-        mSelector: selector,
-        mScope: kAudioObjectPropertyScopeGlobal,
-        mElement: kAudioObjectPropertyElementMain
-    )
-    var cfStr: Unmanaged<CFString>?
-    var size = UInt32(MemoryLayout<Unmanaged<CFString>>.size)
-    let status = withUnsafeMutablePointer(to: &cfStr) { ptr in
-        AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, ptr)
-    }
-    guard status == noErr, let cf = cfStr else {
-        throw CoreAudioError(code: status, op: "StringProperty")
-    }
-    return cf.takeRetainedValue() as String
+    try audioObjectString(deviceID, globalPropertyAddress(selector), op: "StringProperty")
 }


### PR DESCRIPTION
## Summary

`SpeakerCapture` re-implemented the same `AudioObjectGetPropertyData` pattern that `Devices.swift` already had. `defaultOutputDeviceUID()` built a property address, read a default device ID, then re-pointed the address and read the device UID as an `Unmanaged<CFString>` with `takeRetainedValue()`, which is exactly `queryDefaultDevice(selector:)` followed by `queryStringProperty(_:selector:)`. `tapStreamFormat(_:)` did the same fixed-size scalar read that `queryDefaultDevice` does. So the address-build / size / status-check / CFString-retain dance lived in four near-identical copies across two files.

This is a behavior-preserving refactor that lifts that boilerplate into one place so both files share it. The devices enumerated, the values read, the property scopes, the CFString memory management, and the `CoreAudioError` op labels are all unchanged. `vo --doctor` and `--select-device` behave identically.

The variable-length reads (`queryChannelCount`, `queryAllDeviceIDs`) keep their own bodies, since they need `AudioObjectGetPropertyDataSize` plus an allocation step that the scalar helpers do not, and folding them in would have widened the diff for no real gain.

## Changes

- **`Sources/vo/CoreAudio+Property.swift`** (new) adds the shared helpers: a generic fixed-size scalar reader `audioObjectProperty(_:_:into:op:)`, a CFString reader `audioObjectString(_:_:op:)` that preserves the `Unmanaged<CFString>` + `takeRetainedValue()` (+1 retain) handling, and a `globalPropertyAddress(_:)` builder for the common global-scope / main-element address. Each call site still passes its own `op` label so the surfaced `CoreAudioError` wording is unchanged. The scalar reader binds the value through `withUnsafeMutablePointer` to avoid the raw-pointer-from-generic warning.
- **`Sources/vo/AudioSource.swift`** rewrites `SpeakerCapture.defaultOutputDeviceUID()` to a default-device scalar read plus a UID string read (both global scope), and `tapStreamFormat(_:)` to a single scalar read of `kAudioTapPropertyFormat`. Op labels `DefaultOutputDevice`, `OutputDeviceUID`, and `TapFormat` are preserved.
- **`Sources/vo/Devices.swift`** rewrites `queryDefaultDevice(selector:)` and `queryStringProperty(_:selector:)` to call the shared helpers (op labels `DefaultDevice` / `StringProperty` preserved); `queryChannelCount` (input/output scope) and `queryAllDeviceIDs` are left as-is.

## Test plan

- [x] `swift build` clean, no new warnings (the initial generic raw-pointer warning was resolved with `withUnsafeMutablePointer`).
- [x] `./scripts/test.sh` passes (20 tests in 4 suites).
- [ ] Manual on macOS 26 + Apple Silicon: `vo --doctor` still lists input devices with correct names / UIDs / channel counts and the default marker, and `vo --select-device` still enumerates mic / speaker devices and pins the chosen one.
- [ ] Manual: speaker capture still resolves the default output device UID and the tap stream format (no regression in `SpeakerCapture.start()`).