### PR TITLE
docs: show piping vo --json into say as a live interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ Translation lines are shown in dim text under the source. Pairs are emitted in s
 
 `src.confidence` reports the transcription's per-chunk confidence, with `mean` weighted across the chunk and `min` taken from its least-confident run. This is acoustic confidence rather than a correctness guarantee, so a low `min` is a useful cue that a chunk is worth re-listening to. There is no counterpart for `dst`, because the translation framework exposes no quality score. The object is omitted only when no confidence value is available.
 
+### Live interpretation with `say`
+
+`vo --json` emits each finalized translation as soon as it is ready, so piping `dst.text` into `say` turns `vo` into an on-device live interpreter. No network, no API key.
+
+```console
+$ vo --src ja-JP --dst en-US --no-speaker --json \
+    | jq -r --unbuffered '.dst.text // empty' \
+    | while read -r line; do say -v Samantha "$line"; done
+```
+
+`jq --unbuffered` flushes each line as it arrives, so `say` speaks each chunk the moment `vo` finalizes it. `say -v '?'` lists installed voices.
+
 ### Device selection
 
 By default `vo` captures from the system default microphone and output device and follows them. If the default input or output changes mid-session (you switch output, or plug in headphones), `vo` rebuilds that channel on the new default and keeps going instead of stopping.


### PR DESCRIPTION
## Summary

The README documents the JSONL output as a structured stream but does not make the streaming part visible. Piping `dst.text` into macOS's built-in `say` is a one-liner that turns `vo` into an on-device live interpreter, and it exercises every property the README otherwise only claims: finalized chunks arrive as they are ready, are emitted in source order, and need no network or API key. Adding it as a small example under JSONL output gives a reader the streaming behavior in use, not just described.

## Changes

- Add a `### Live interpretation with `say`` subsection right after the JSONL output section, with the `vo --json | jq --unbuffered | while read | say` pipeline as a copy-paste recipe.
- Call out `jq --unbuffered` as the part that makes the chunk-by-chunk timing work, and mention `say -v '?'` for picking a voice.
- Use `--no-speaker` in the example so `say`'s own output is not re-captured.