### PR TITLE
feat: --src / --dst take locale lists for bidirectional translation

### DIFF
--- a/Sources/vo/Listen.swift
+++ b/Sources/vo/Listen.swift
@@ -303,15 +303,30 @@ private func bannerLanguagePair(sourceLocales: [Locale], targetLocales: [Locale]
 }
 
 /// Split a comma-separated locale list flag value into trimmed Locale instances.
-/// Empty list or an empty entry produces a ValidationError naming the flag.
+/// Empty list, empty entries, and duplicate locales each produce a ValidationError
+/// naming the flag. Duplicates are rejected because ChunkReconciler keys per-region
+/// candidates and TranslationLane keys translator pipes by `identifier(.bcp47)`,
+/// so a repeat would either lock the reconciler into always waiting its 300ms
+/// timeout (count stays under nLocales because two transcribers share one slot)
+/// or silently overwrite a translator lane. Newlines are trimmed alongside spaces
+/// so `--src "$(cat list.txt)"`-style usage does not leak a trailing newline into
+/// the SpeechTranscriber locale lookup later.
 private func parseLocaleList(_ raw: String, flag: String) throws -> [Locale] {
     let parts = raw.split(separator: ",", omittingEmptySubsequences: false).map {
-        $0.trimmingCharacters(in: .whitespaces)
+        $0.trimmingCharacters(in: .whitespacesAndNewlines)
     }
     guard !parts.isEmpty, parts.allSatisfy({ !$0.isEmpty }) else {
         throw ValidationError("\(flag) cannot be empty or contain empty entries.")
     }
-    return parts.map { Locale(identifier: $0) }
+    let locales = parts.map { Locale(identifier: $0) }
+    var seen: Set<String> = []
+    for locale in locales {
+        let id = locale.identifier(.bcp47)
+        if !seen.insert(id).inserted {
+            throw ValidationError("\(flag) contains duplicate locale \(id).")
+        }
+    }
+    return locales
 }
 
 /// Wrap a string in a 256-color foreground SGR escape. Matches the renderer's palette.

--- a/Sources/vo/Listen.swift
+++ b/Sources/vo/Listen.swift
@@ -45,8 +45,22 @@ func runListen(
     // still checks Speech Recognition).
     Responsibility.reexecAsResponsibleProcess()
 
-    let sourceLocale = Locale(identifier: src)
-    let targetLocale = dst.map { Locale(identifier: $0) }
+    let sourceLocales = try parseLocaleList(src, flag: "--src")
+    let targetLocales: [Locale]?
+    if let dst {
+        let parsed = try parseLocaleList(dst, flag: "--dst")
+        guard parsed.count == sourceLocales.count else {
+            throw ValidationError("--dst must have the same number of locales as --src (got \(sourceLocales.count) source, \(parsed.count) target).")
+        }
+        targetLocales = parsed
+    } else {
+        targetLocales = nil
+    }
+    // For multi-source mode the renderer carries dummy defaults; every finalized
+    // chunk arrives with srcLang / dstLang overrides set by the reconciler. For
+    // single-source mode the defaults are what JSONL uses, so pass the actual id.
+    let primarySource = sourceLocales[0]
+    let primaryTarget = targetLocales?[0]
 
     // Resolve pinned devices before any capture starts. Done after the re-exec so the
     // prompt runs once in the disclaimed child (which owns stdin), and before the
@@ -95,16 +109,16 @@ func runListen(
 
     let renderer = StreamRenderer(
         mode: mode,
-        sourceLang: sourceLocale.identifier(.bcp47),
-        targetLang: targetLocale?.identifier(.bcp47) ?? "",
-        translationEnabled: targetLocale != nil,
+        sourceLang: primarySource.identifier(.bcp47),
+        targetLang: primaryTarget?.identifier(.bcp47) ?? "",
+        translationEnabled: targetLocales != nil,
         showChannelLabel: showChannelLabel,
         logSink: sessionLog
     )
 
     let pipeline = Pipeline(
-        sourceLocale: sourceLocale,
-        targetLocale: targetLocale,
+        sourceLocales: sourceLocales,
+        targetLocales: targetLocales,
         renderer: renderer,
         enableMic: mic,
         enableSpeaker: speaker,
@@ -119,14 +133,14 @@ func runListen(
         if let inputURL {
             printFileBanner(
                 inputURL: inputURL,
-                sourceLocale: sourceLocale,
-                targetLocale: targetLocale
+                sourceLocales: sourceLocales,
+                targetLocales: targetLocales
             )
         } else {
             let deviceLabels = resolvedCaptureDeviceLabels(mic: mic, speaker: speaker, selected: selectedDevices)
             printBanner(
-                sourceLocale: sourceLocale,
-                targetLocale: targetLocale,
+                sourceLocales: sourceLocales,
+                targetLocales: targetLocales,
                 mic: mic,
                 speaker: speaker,
                 micDevice: deviceLabels.mic,
@@ -233,8 +247,8 @@ private func finalizeSession(
 // MARK: - Banner / Summary
 
 private func printBanner(
-    sourceLocale: Locale,
-    targetLocale: Locale?,
+    sourceLocales: [Locale],
+    targetLocales: [Locale]?,
     mic: Bool,
     speaker: Bool,
     micDevice: CaptureDeviceLabel?,
@@ -243,12 +257,7 @@ private func printBanner(
     let channels = [mic ? "mic" : nil, speaker ? "speaker" : nil]
         .compactMap { $0 }
         .joined(separator: " + ")
-    let langs: String
-    if let t = targetLocale {
-        langs = "\(sourceLocale.identifier(.bcp47)) → \(t.identifier(.bcp47))"
-    } else {
-        langs = sourceLocale.identifier(.bcp47)
-    }
+    let langs = bannerLanguagePair(sourceLocales: sourceLocales, targetLocales: targetLocales)
     let version = Vo.configuration.version
     print("vo \(version) — listening on \(channels) (\(langs))")
 
@@ -271,19 +280,38 @@ private func printBanner(
 
 private func printFileBanner(
     inputURL: URL,
-    sourceLocale: Locale,
-    targetLocale: Locale?
+    sourceLocales: [Locale],
+    targetLocales: [Locale]?
 ) {
-    let langs: String
-    if let t = targetLocale {
-        langs = "\(sourceLocale.identifier(.bcp47)) → \(t.identifier(.bcp47))"
-    } else {
-        langs = sourceLocale.identifier(.bcp47)
-    }
+    let langs = bannerLanguagePair(sourceLocales: sourceLocales, targetLocales: targetLocales)
     let version = Vo.configuration.version
     let display = inputURL.isFileURL ? inputURL.path : inputURL.absoluteString
     print("vo \(version) — transcribing \(display) (\(langs))")
     print("")
+}
+
+/// Render the locale list pair shown in the banner. Single-locale collapses to the
+/// familiar "en-US" / "en-US → ja-JP" forms; multi-locale uses a comma-separated
+/// list on each side matching what the user typed.
+private func bannerLanguagePair(sourceLocales: [Locale], targetLocales: [Locale]?) -> String {
+    let srcStr = sourceLocales.map { $0.identifier(.bcp47) }.joined(separator: ",")
+    if let targetLocales {
+        let dstStr = targetLocales.map { $0.identifier(.bcp47) }.joined(separator: ",")
+        return "\(srcStr) → \(dstStr)"
+    }
+    return srcStr
+}
+
+/// Split a comma-separated locale list flag value into trimmed Locale instances.
+/// Empty list or an empty entry produces a ValidationError naming the flag.
+private func parseLocaleList(_ raw: String, flag: String) throws -> [Locale] {
+    let parts = raw.split(separator: ",", omittingEmptySubsequences: false).map {
+        $0.trimmingCharacters(in: .whitespaces)
+    }
+    guard !parts.isEmpty, parts.allSatisfy({ !$0.isEmpty }) else {
+        throw ValidationError("\(flag) cannot be empty or contain empty entries.")
+    }
+    return parts.map { Locale(identifier: $0) }
 }
 
 /// Wrap a string in a 256-color foreground SGR escape. Matches the renderer's palette.

--- a/Sources/vo/Listen.swift
+++ b/Sources/vo/Listen.swift
@@ -292,7 +292,9 @@ private func printFileBanner(
 
 /// Render the locale list pair shown in the banner. Single-locale collapses to the
 /// familiar "en-US" / "en-US → ja-JP" forms; multi-locale uses a comma-separated
-/// list on each side matching what the user typed.
+/// list of normalized BCP-47 identifiers on each side (so `en_US` shows as
+/// `en-US`, surrounding whitespace already stripped by `parseLocaleList`), which
+/// may differ slightly from the exact text the user typed.
 private func bannerLanguagePair(sourceLocales: [Locale], targetLocales: [Locale]?) -> String {
     let srcStr = sourceLocales.map { $0.identifier(.bcp47) }.joined(separator: ",")
     if let targetLocales {

--- a/Sources/vo/Pipeline.swift
+++ b/Sources/vo/Pipeline.swift
@@ -919,10 +919,15 @@ struct Pipeline {
         } catch {
             resampler.cancel()
             for b in inputBuilders { b.finish() }
+            // Drain pending reconciler winners BEFORE closing the lanes, mirroring
+            // the success-path order below. emitWinner's onEmit yields into
+            // lane.builder; once the builder is finished those yields are silently
+            // dropped, leaving the renderer's commitQueue holding an untranslated
+            // pair the error path then has no way to satisfy.
+            await reconciler.finish()
             for lane in lanes.values { lane.builder.finish() }
             for lane in lanes.values { lane.translator.cancel() }
             await stopper()
-            await reconciler.finish()
             throw error
         }
 
@@ -1348,10 +1353,15 @@ struct Pipeline {
             // alone leaves the CheckedContinuation unresumed and the resampler task
             // strands, leaking its frame and the buffered AVAudioPCMBuffers.
             for buf in inputBuffers { await buf.finish() }
+            // Drain pending reconciler winners BEFORE closing the lanes, mirroring
+            // the success-path order below. emitWinner's onEmit yields into
+            // lane.builder; once the builder is finished those yields are silently
+            // dropped, leaving the renderer's commitQueue holding an untranslated
+            // pair the error path then has no way to satisfy.
+            await reconciler.finish()
             for lane in lanes.values { lane.builder.finish() }
             for lane in lanes.values { lane.translator.cancel() }
             await stopper()
-            await reconciler.finish()
             throw error
         }
 

--- a/Sources/vo/Pipeline.swift
+++ b/Sources/vo/Pipeline.swift
@@ -235,8 +235,13 @@ final class RebindBox: @unchecked Sendable {
 ///   - all N source locales have contributed a candidate, or
 ///   - 300 ms has elapsed since the first candidate for that region arrived
 /// The winner is the candidate with the highest `confidence.mean`. A candidate that
-/// arrives after its region already fired is dropped via the short-lived
-/// `recentlyEmitted` window so the same utterance never emits twice.
+/// arrives after its region already fired is dropped via the `recentlyEmitted` audio
+/// range list so the same utterance never emits twice. We prune that list by audio
+/// range (not wall clock) because a slow-language transcriber can lag the fast one
+/// by seconds on long utterances; a wall-clock TTL would expire too early and let
+/// the laggard double-emit. Since each transcriber moves monotonically forward on
+/// the session timeline, an emitted region with `unionEnd <= incoming.audioStart`
+/// can never overlap a future chunk and is safe to drop.
 ///
 /// `nLocales == 1` is the legacy single-source mode; the reconciler short-circuits
 /// straight to `onEmit` with no buffering or timer, so output latency is unchanged.
@@ -259,18 +264,17 @@ actor ChunkReconciler {
     private struct EmittedRegion {
         let unionStart: Double
         let unionEnd: Double
-        let expiresAt: Date
     }
 
     private let nLocales: Int
     private let timeoutSeconds: Double
     private let onEmit: @Sendable (Candidate) async -> Void
     private var pendings: [PendingRegion] = []
-    /// Regions emitted within the last `recentlyEmittedTTL` seconds. A late-arriving
-    /// candidate that overlaps one of these is dropped instead of starting a fresh
-    /// pending and double-emitting the same utterance.
+    /// Audio-range regions that have already been emitted. A late-arriving candidate
+    /// that overlaps one of these is dropped to prevent double output. Pruned by
+    /// audio range (see `receive`), not wall clock, so a slow transcriber that lags
+    /// the fast one by seconds still hits this guard.
     private var recentlyEmitted: [EmittedRegion] = []
-    private let recentlyEmittedTTL: TimeInterval = 0.5
     private var finished = false
 
     init(
@@ -304,7 +308,12 @@ actor ChunkReconciler {
             return
         }
 
-        pruneExpiredEmissions()
+        // Drop emitted regions that ended at or before this candidate's start;
+        // each transcriber moves monotonically forward, so any future chunk's
+        // audioStart will be >= start, meaning these regions can no longer
+        // overlap anything. This keeps `recentlyEmitted` bounded without a
+        // wall-clock TTL that would race a slow-language transcriber.
+        recentlyEmitted.removeAll { $0.unionEnd <= start }
 
         // A candidate overlapping a recently-emitted region was already represented
         // by an earlier winner; drop to prevent double output.
@@ -389,16 +398,10 @@ actor ChunkReconciler {
         // is dropped instead of creating a new region.
         recentlyEmitted.append(EmittedRegion(
             unionStart: region.unionStart,
-            unionEnd: region.unionEnd,
-            expiresAt: Date().addingTimeInterval(recentlyEmittedTTL)
+            unionEnd: region.unionEnd
         ))
 
         await onEmit(winner)
-    }
-
-    private func pruneExpiredEmissions() {
-        let now = Date()
-        recentlyEmitted.removeAll { $0.expiresAt < now }
     }
 
     private func overlaps(aStart: Double, aEnd: Double, bStart: Double, bEnd: Double) -> Bool {

--- a/Sources/vo/Pipeline.swift
+++ b/Sources/vo/Pipeline.swift
@@ -220,6 +220,200 @@ final class RebindBox: @unchecked Sendable {
     }
 }
 
+/// Per-channel reconciler for the multi-source (auto-detect) pipeline. Each enabled
+/// source locale runs its own SpeechTranscriber on the same audio. They independently
+/// segment by their own VAD, so the same utterance arrives as N (slightly offset)
+/// finalized chunks. The reconciler matches them by `audio.range` overlap and emits
+/// exactly one winner per utterance to the renderer + translator routing.
+///
+/// Matching: a candidate joins an existing pending region when
+///   overlap(region, candidate) / min(region.length, candidate.length) > 0.5
+/// (the shorter side must be majority-covered). The pending region's union expands
+/// to include the new candidate so subsequent candidates can still match.
+///
+/// Emission: a region fires when either
+///   - all N source locales have contributed a candidate, or
+///   - 300 ms has elapsed since the first candidate for that region arrived
+/// The winner is the candidate with the highest `confidence.mean`. A candidate that
+/// arrives after its region already fired is dropped via the short-lived
+/// `recentlyEmitted` window so the same utterance never emits twice.
+///
+/// `nLocales == 1` is the legacy single-source mode; the reconciler short-circuits
+/// straight to `onEmit` with no buffering or timer, so output latency is unchanged.
+actor ChunkReconciler {
+    struct Candidate: Sendable {
+        let locale: Locale
+        let text: String
+        let timing: ChunkTiming
+        let confidence: ChunkConfidence?
+    }
+
+    private struct PendingRegion {
+        let id: UUID
+        var unionStart: Double
+        var unionEnd: Double
+        var candidates: [String: Candidate]   // locale.identifier(.bcp47) -> candidate
+        var timeoutTask: Task<Void, Never>?
+    }
+
+    private struct EmittedRegion {
+        let unionStart: Double
+        let unionEnd: Double
+        let expiresAt: Date
+    }
+
+    private let nLocales: Int
+    private let timeoutSeconds: Double
+    private let onEmit: @Sendable (Candidate) async -> Void
+    private var pendings: [PendingRegion] = []
+    /// Regions emitted within the last `recentlyEmittedTTL` seconds. A late-arriving
+    /// candidate that overlaps one of these is dropped instead of starting a fresh
+    /// pending and double-emitting the same utterance.
+    private var recentlyEmitted: [EmittedRegion] = []
+    private let recentlyEmittedTTL: TimeInterval = 0.5
+    private var finished = false
+
+    init(
+        nLocales: Int,
+        timeoutSeconds: Double = 0.3,
+        onEmit: @escaping @Sendable (Candidate) async -> Void
+    ) {
+        precondition(nLocales >= 1)
+        self.nLocales = nLocales
+        self.timeoutSeconds = timeoutSeconds
+        self.onEmit = onEmit
+    }
+
+    /// Submit a finalized candidate from one source-locale transcriber. The actor
+    /// decides whether it merges into an existing pending region, opens a new one,
+    /// or short-circuits straight to emission (n=1 or invalid timing).
+    func receive(_ candidate: Candidate) async {
+        if finished { return }
+
+        // Single-source: nothing to reconcile, emit synchronously.
+        if nLocales == 1 {
+            await onEmit(candidate)
+            return
+        }
+
+        guard let start = candidate.timing.audioStart,
+              let end = candidate.timing.audioEnd,
+              end > start else {
+            // No timing → can't overlap-match. Emit standalone rather than swallow.
+            await onEmit(candidate)
+            return
+        }
+
+        pruneExpiredEmissions()
+
+        // A candidate overlapping a recently-emitted region was already represented
+        // by an earlier winner; drop to prevent double output.
+        if recentlyEmitted.contains(where: { overlaps(aStart: $0.unionStart, aEnd: $0.unionEnd, bStart: start, bEnd: end) }) {
+            return
+        }
+
+        if let idx = pendings.firstIndex(where: { p in
+            overlaps(aStart: p.unionStart, aEnd: p.unionEnd, bStart: start, bEnd: end)
+        }) {
+            // Same locale arriving twice (e.g. two short fragments from one transcriber
+            // overlapping one chunk from the other) keeps the higher-mean one. The
+            // alternative — replacing unconditionally — would discard a high-confidence
+            // first fragment in favour of a noisy continuation.
+            let key = candidate.locale.identifier(.bcp47)
+            if let existing = pendings[idx].candidates[key] {
+                let existingMean = existing.confidence?.mean ?? 0
+                let newMean = candidate.confidence?.mean ?? 0
+                if newMean > existingMean {
+                    pendings[idx].candidates[key] = candidate
+                }
+            } else {
+                pendings[idx].candidates[key] = candidate
+            }
+            pendings[idx].unionStart = Swift.min(pendings[idx].unionStart, start)
+            pendings[idx].unionEnd = Swift.max(pendings[idx].unionEnd, end)
+
+            if pendings[idx].candidates.count >= nLocales {
+                let region = pendings.remove(at: idx)
+                region.timeoutTask?.cancel()
+                await emitWinner(from: region)
+            }
+        } else {
+            // First candidate for a new region. Schedule a one-shot timeout.
+            let id = UUID()
+            var region = PendingRegion(
+                id: id,
+                unionStart: start,
+                unionEnd: end,
+                candidates: [candidate.locale.identifier(.bcp47): candidate],
+                timeoutTask: nil
+            )
+            let timeoutSeconds = self.timeoutSeconds
+            region.timeoutTask = Task { [weak self] in
+                try? await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
+                if Task.isCancelled { return }
+                await self?.fireTimeout(id: id)
+            }
+            pendings.append(region)
+        }
+    }
+
+    /// Cancel all timers and emit whatever has been collected so far. Called by the
+    /// channel teardown path so a pending region never strands its candidate after
+    /// the transcribers have finished.
+    func finish() async {
+        if finished { return }
+        finished = true
+        let remaining = pendings
+        pendings.removeAll()
+        for region in remaining {
+            region.timeoutTask?.cancel()
+            await emitWinner(from: region)
+        }
+    }
+
+    // MARK: - Internals
+
+    private func fireTimeout(id: UUID) async {
+        if finished { return }
+        guard let idx = pendings.firstIndex(where: { $0.id == id }) else { return }
+        let region = pendings.remove(at: idx)
+        await emitWinner(from: region)
+    }
+
+    private func emitWinner(from region: PendingRegion) async {
+        guard let winner = region.candidates.values.max(by: {
+            ($0.confidence?.mean ?? 0) < ($1.confidence?.mean ?? 0)
+        }) else { return }
+
+        // Remember this emission so a stray late candidate for the same utterance
+        // is dropped instead of creating a new region.
+        recentlyEmitted.append(EmittedRegion(
+            unionStart: region.unionStart,
+            unionEnd: region.unionEnd,
+            expiresAt: Date().addingTimeInterval(recentlyEmittedTTL)
+        ))
+
+        await onEmit(winner)
+    }
+
+    private func pruneExpiredEmissions() {
+        let now = Date()
+        recentlyEmitted.removeAll { $0.expiresAt < now }
+    }
+
+    private func overlaps(aStart: Double, aEnd: Double, bStart: Double, bEnd: Double) -> Bool {
+        let ovStart = Swift.max(aStart, bStart)
+        let ovEnd = Swift.min(aEnd, bEnd)
+        let ov = ovEnd - ovStart
+        guard ov > 0 else { return false }
+        let aLen = aEnd - aStart
+        let bLen = bEnd - bStart
+        let shorter = Swift.min(aLen, bLen)
+        guard shorter > 0 else { return false }
+        return ov / shorter > 0.5
+    }
+}
+
 /// End-to-end pipeline that orchestrates one or more audio channels.
 ///
 /// For each enabled channel:
@@ -230,8 +424,16 @@ final class RebindBox: @unchecked Sendable {
 /// Mic and Speaker run concurrently in a TaskGroup but share one renderer + one seq counter,
 /// so the output order reflects which channel finalized first.
 struct Pipeline {
-    let sourceLocale: Locale
-    let targetLocale: Locale?  // nil = transcribe only, no translation
+    /// One or more source locales. When the list has more than one entry, every
+    /// channel runs a SpeechTranscriber per locale in parallel and the
+    /// `ChunkReconciler` picks one winner per utterance via overlap-based matching
+    /// (see ChunkReconciler for the algorithm).
+    let sourceLocales: [Locale]
+    /// Target locales for translation, position-paired with `sourceLocales`. nil
+    /// → transcribe only. When provided, length must match `sourceLocales` (Listen
+    /// validates this), so the per-utterance routing `srcLocales[i] → dstLocales[i]`
+    /// is a direct array lookup.
+    let targetLocales: [Locale]?
     let renderer: any Renderer
     let enableMic: Bool
     let enableSpeaker: Bool
@@ -250,13 +452,18 @@ struct Pipeline {
         let counter = SeqCounter()
 
         // Resolve models once, before any channel starts. Both channels share the
-        // source locale, so doing this here (instead of per-channel) avoids a double
-        // download and lets us emit a single progress line. The speech asset can be
-        // fetched headlessly; the translation model cannot, so we fail fast with
-        // install instructions rather than letting every chunk surface a failure.
-        try await ensureSpeechAsset(locale: sourceLocale)
-        if let targetLocale {
-            try await ensureTranslationModel(source: sourceLocale, target: targetLocale)
+        // source-locale list, so doing this here (instead of per-channel) avoids a
+        // double download and lets us emit a single progress line per locale. The
+        // speech asset can be fetched headlessly; the translation model cannot, so
+        // we fail fast with install instructions rather than letting every chunk
+        // surface a failure.
+        for locale in sourceLocales {
+            try await ensureSpeechAsset(locale: locale)
+        }
+        if let targetLocales {
+            for (src, dst) in zip(sourceLocales, targetLocales) {
+                try await ensureTranslationModel(source: src, target: dst)
+            }
         }
 
         // File mode runs a single channel with its own timeline origin at 0, so audio
@@ -301,12 +508,19 @@ struct Pipeline {
 
     // MARK: - Per-channel
 
-    private func runChannel(
-        channel: AudioChannel,
-        counter: SeqCounter,
-        sessionStart: Double
-    ) async throws {
-        let willTranslate = targetLocale != nil
+    /// Per source-locale stack: one transcriber + analyzer + analyzer-input stream.
+    /// Audio fans out from one resampler to every entry's `inputBuilder`. The
+    /// transcribers run independently; their finalized chunks meet at the
+    /// `ChunkReconciler` which picks the winning locale per utterance.
+    private struct PerLocale {
+        let locale: Locale
+        let transcriber: SpeechTranscriber
+        let analyzer: SpeechAnalyzer
+        let inputSeq: AsyncStream<AnalyzerInput>
+        let inputBuilder: AsyncStream<AnalyzerInput>.Continuation
+    }
+
+    private func makeTranscriberStack(for locale: Locale) -> SpeechTranscriber {
         // `.fastResults` biases the transcriber toward a shorter context window so
         // both volatile and finalized chunks arrive with lower latency. Apple
         // documents an accuracy trade-off but it is acceptable here: the live
@@ -317,28 +531,48 @@ struct Pipeline {
         // give us; we spell it out explicitly to keep the trade-off readable.
         // Request per-run transcription confidence alongside the time range. It is
         // aggregated per chunk (mean + min) and emitted under `src.confidence`. Note
-        // the value is acoustic per-character confidence, not word correctness.
-        let transcriber = SpeechTranscriber(
-            locale: sourceLocale,
+        // the value is acoustic per-character confidence, not word correctness, but
+        // for multi-source auto-detect mode the mean is also the primary signal
+        // ChunkReconciler uses to pick a winner across locales.
+        SpeechTranscriber(
+            locale: locale,
             transcriptionOptions: [],
             reportingOptions: [.volatileResults, .fastResults],
             attributeOptions: [.audioTimeRange, .transcriptionConfidence]
         )
-        let analyzer = SpeechAnalyzer(modules: [transcriber])
+    }
 
-        guard let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: [transcriber]) else {
+    private func runChannel(
+        channel: AudioChannel,
+        counter: SeqCounter,
+        sessionStart: Double
+    ) async throws {
+        let willTranslate = targetLocales != nil
+
+        // One transcriber + analyzer + input stream per source locale. With a single
+        // locale this collapses to one entry and the ChunkReconciler fast-paths
+        // straight through, so the auto-detect machinery costs nothing in that case.
+        var perLocale: [PerLocale] = []
+        for src in sourceLocales {
+            let t = makeTranscriberStack(for: src)
+            let a = SpeechAnalyzer(modules: [t])
+            let (seq, builder) = AsyncStream<AnalyzerInput>.makeStream()
+            perLocale.append(PerLocale(locale: src, transcriber: t, analyzer: a, inputSeq: seq, inputBuilder: builder))
+        }
+
+        guard let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: perLocale.map { $0.transcriber }) else {
             throw VoError.noCompatibleAudioFormat
         }
 
         // Start audio capture and the resampler BEFORE warming the analyzer so
         // any speech the user produces during the ANE compile window lands in
-        // the inputBuilder buffer instead of being lost. Without this ordering
+        // the inputBuilder buffers instead of being lost. Without this ordering
         // the ~1.5 s `prepareToAnalyze` would silently drop the first words of
         // a session.
         //
         // An unpinned channel follows the system default device: if the default
         // changes mid-session, the capture is rebuilt on the new default and keeps
-        // feeding the same analyzer, so the session continues instead of stopping.
+        // feeding the same analyzers, so the session continues instead of stopping.
         // A pinned (--select-device) channel installs no device-change listener, so
         // makeCapture below runs exactly once.
         let rebind = RebindBox()
@@ -383,57 +617,124 @@ struct Pipeline {
         // capture before any save prompt blocks the main task.
         await stops.register(AsyncStopper(action: stopper))
 
-        let (inputSeq, inputBuilder) = AsyncStream<AnalyzerInput>.makeStream()
-
+        let inputBuilders = perLocale.map { $0.inputBuilder }
         let resampler = makeResampler(
             channel: channel,
             sessionStart: sessionStart,
             analyzerFormat: analyzerFormat,
             firstStream: firstStream,
             rebind: rebind,
-            inputBuilder: inputBuilder,
+            inputBuilders: inputBuilders,
             makeCapture: makeCapture
         )
 
-        // Warm the model / ANE in parallel with the now-flowing capture so the
+        // Warm each model / ANE in parallel with the now-flowing capture so the
         // first finalized chunk comes back in ~1.45 s instead of ~2.2 s. If
-        // either prepare/start throws, the resampler we just spawned would be
+        // any prepare/start throws, the resampler we just spawned would be
         // orphaned, so cancel it explicitly before propagating.
         do {
-            try await analyzer.prepareToAnalyze(in: analyzerFormat)
-            try await analyzer.start(inputSequence: inputSeq)
+            for p in perLocale {
+                try await p.analyzer.prepareToAnalyze(in: analyzerFormat)
+                try await p.analyzer.start(inputSequence: p.inputSeq)
+            }
         } catch {
             resampler.cancel()
-            inputBuilder.finish()
+            for b in inputBuilders { b.finish() }
             await stopper()
             throw error
         }
 
-        // Translation worker for this channel (only when targetLocale is set).
-        let (chunkSeq, chunkBuilder) = AsyncStream<(Int, String)>.makeStream()
-        let translator = makeTranslator(chunkSeq: chunkSeq)
+        // One translator + chunk pipe per (src → dst) pair. Built up-front and held as
+        // `let` so the reconciler's @Sendable onEmit closure can capture without a
+        // mutable-var diagnostic. Keyed by source-locale BCP-47 so the reconciler's
+        // winner routes in O(1).
+        let lanes: [String: TranslationLane] = makeTranslationLanes()
+        let dstLangByLocale: [String: String] = {
+            guard let targetLocales else { return [:] }
+            var m: [String: String] = [:]
+            for (i, src) in sourceLocales.enumerated() {
+                m[src.identifier(.bcp47)] = targetLocales[i].identifier(.bcp47)
+            }
+            return m
+        }()
 
-        // Drain transcriber results.
-        do {
-            try await drainTranscriberResults(
+        // Reconciler: receives finalized candidates from every per-locale transcriber,
+        // picks a winner per utterance, and assigns the renderer's monotonic `seq` at
+        // emission time so renderer source-order commit stays unaffected by reconciliation.
+        let rendererRef = renderer
+        let reconciler = ChunkReconciler(nLocales: sourceLocales.count) { winner in
+            let seq = await counter.next()
+            let srcLang = winner.locale.identifier(.bcp47)
+            let dstLang = dstLangByLocale[srcLang]
+            await rendererRef.handle(.finalized(
                 channel: channel,
-                counter: counter,
-                transcriber: transcriber,
-                willTranslate: willTranslate,
-                chunkBuilder: chunkBuilder
-            )
+                seq: seq,
+                source: winner.text,
+                timing: winner.timing,
+                confidence: winner.confidence,
+                srcLangOverride: srcLang,
+                dstLangOverride: dstLang
+            ))
+            if willTranslate, let lane = lanes[srcLang] {
+                lane.builder.yield((seq, winner.text))
+            }
+        }
+
+        // Drain each transcriber's results concurrently. Volatile updates from every
+        // locale flow straight to the renderer (the live region is per-channel, not
+        // per-locale, so the latest-arriving fragment wins); finalized chunks go to
+        // the reconciler with a wall-clock-now timestamp.
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                for p in perLocale {
+                    group.addTask {
+                        try await self.drainTranscriberResults(
+                            channel: channel,
+                            transcriber: p.transcriber,
+                            locale: p.locale,
+                            reconciler: reconciler,
+                            timestampFor: { _ in Date() }
+                        )
+                    }
+                }
+                try await group.waitForAll()
+            }
         } catch {
             resampler.cancel()
-            chunkBuilder.finish()
-            translator?.cancel()
+            for b in inputBuilders { b.finish() }
+            for lane in lanes.values { lane.builder.finish() }
+            for lane in lanes.values { lane.translator.cancel() }
             await stopper()
+            await reconciler.finish()
             throw error
         }
 
         resampler.cancel()
         await stopper()
-        chunkBuilder.finish()
-        await translator?.value
+        await reconciler.finish()
+        for lane in lanes.values { lane.builder.finish() }
+        for lane in lanes.values { await lane.translator.value }
+    }
+
+    /// One translator + matching chunk-feeder per (src → dst) pair, keyed by the
+    /// source locale's BCP-47 identifier. Empty when `targetLocales` is nil
+    /// (transcribe-only). Built once per channel call so the lookup table stays
+    /// immutable and captures cleanly into the reconciler's Sendable closure.
+    private struct TranslationLane: Sendable {
+        let translator: Task<Void, Never>
+        let builder: AsyncStream<(Int, String)>.Continuation
+    }
+
+    private func makeTranslationLanes() -> [String: TranslationLane] {
+        guard let targetLocales else { return [:] }
+        var m: [String: TranslationLane] = [:]
+        for (i, src) in sourceLocales.enumerated() {
+            let dst = targetLocales[i]
+            let (chunkSeq, builder) = AsyncStream<(Int, String)>.makeStream()
+            let translator = makeTranslator(source: src, target: dst, chunkSeq: chunkSeq)
+            m[src.identifier(.bcp47)] = TranslationLane(translator: translator, builder: builder)
+        }
+        return m
     }
 
     /// Resample + device-follow task: pull from the active capture, convert to the
@@ -447,7 +748,7 @@ struct Pipeline {
         analyzerFormat: AVAudioFormat,
         firstStream: AsyncStream<TimedBuffer>,
         rebind: RebindBox,
-        inputBuilder: AsyncStream<AnalyzerInput>.Continuation,
+        inputBuilders: [AsyncStream<AnalyzerInput>.Continuation],
         makeCapture: @escaping @Sendable () async throws -> AsyncStream<TimedBuffer>
     ) -> Task<Void, Never> {
         Task.detached {
@@ -472,8 +773,10 @@ struct Pipeline {
                     // device-rebind reopen gap, and a hole left by a failed convert all
                     // collapse to "fill [fedEnd, h) with silence". A near-zero span rounds
                     // to no samples and is skipped, so a contiguous stream injects nothing.
+                    // Each analyzer needs its own AnalyzerInput so they iterate the same
+                    // PCM buffer independently.
                     if let silence = makeSilentBuffer(seconds: h - reference, format: analyzerFormat) {
-                        inputBuilder.yield(AnalyzerInput(buffer: silence))
+                        for b in inputBuilders { b.yield(AnalyzerInput(buffer: silence)) }
                     }
                     // Advance the fed position past h only by audio actually fed. If the
                     // convert fails, the hole stays open and the next buffer bridges it with
@@ -481,7 +784,7 @@ struct Pipeline {
                     // pre-conversion duration in seconds is resampling-invariant, so it is
                     // the right amount to advance this host-time marker by.
                     if let converted = convertBuffer(timed.buffer, to: analyzerFormat) {
-                        inputBuilder.yield(AnalyzerInput(buffer: converted))
+                        for b in inputBuilders { b.yield(AnalyzerInput(buffer: converted)) }
                         fedEndHostTime = h + Double(timed.buffer.frameLength) / timed.buffer.format.sampleRate
                     } else {
                         fedEndHostTime = h
@@ -504,17 +807,31 @@ struct Pipeline {
                     break
                 }
             }
-            inputBuilder.finish()
+            for b in inputBuilders { b.finish() }
         }
     }
 
-    /// Translation worker for this channel. Returns nil when no target locale is set
-    /// (transcribe-only), so the caller skips translation teardown.
+    /// Translation worker for one (src → dst) locale pair. The caller spawns one of
+    /// these per pair in the source-locale list and routes each finalized chunk's
+    /// text to the worker matching the winning locale.
+    ///
+    /// Same-language pair (e.g. `--src ja-JP --dst ja-JP`, useful when one direction
+    /// of a bidirectional setup should pass through untranslated) bypasses the
+    /// TranslationSession entirely and echoes source text as target. The Translation
+    /// framework rejects identity pairs as unsupported, so we must not call it.
+    ///
     /// TranslationSession is non-Sendable so we create it inside the Task closure.
-    private func makeTranslator(chunkSeq: AsyncStream<(Int, String)>) -> Task<Void, Never>? {
-        guard let targetLang = targetLocale?.language else { return nil }
+    private func makeTranslator(source: Locale, target: Locale, chunkSeq: AsyncStream<(Int, String)>) -> Task<Void, Never> {
         let renderer = renderer
-        let sourceLang = sourceLocale.language
+        if isSameLanguage(source, target) {
+            return Task {
+                for await (seq, text) in chunkSeq {
+                    await renderer.handle(.translated(seq: seq, target: text))
+                }
+            }
+        }
+        let sourceLang = source.language
+        let targetLang = target.language
         return Task {
             let box = SendableTranslationSession(inner: TranslationSession(installedSource: sourceLang, target: targetLang))
             // run() already verified the pair via ensureTranslationModel (it throws
@@ -553,15 +870,22 @@ struct Pipeline {
         }
     }
 
-    /// Drain the transcriber's result stream, emitting volatile previews and finalized
-    /// chunks to the renderer (and finalized source text to the translator when enabled).
+    /// Drain one transcriber's result stream. Volatile previews flow straight to the
+    /// renderer's per-channel live region; finalized chunks become candidates fed to
+    /// the per-channel `ChunkReconciler`, which picks one winner per utterance across
+    /// every source-locale transcriber sharing the channel.
+    ///
+    /// `timestampFor` returns the wall-clock instant a finalized chunk represents.
+    /// Live mode passes `_ in Date()` (now); file mode passes
+    /// `audioStart in localEpoch + audioStart` so timestamp tracks the file's own timeline.
     private func drainTranscriberResults(
         channel: AudioChannel,
-        counter: SeqCounter,
         transcriber: SpeechTranscriber,
-        willTranslate: Bool,
-        chunkBuilder: AsyncStream<(Int, String)>.Continuation
+        locale: Locale,
+        reconciler: ChunkReconciler,
+        timestampFor: @Sendable (Double?) -> Date
     ) async throws {
+        let renderer = renderer
         for try await result in transcriber.results {
             // SpeechTranscriber emits every chunk after the first with a leading
             // space (stream-concatenation artifact). Trim so TTY columns stay
@@ -571,7 +895,6 @@ struct Pipeline {
                 // Whitespace-only finals carry no content; skip them so they
                 // don't burn a seq or emit blank lines.
                 guard !text.isEmpty else { continue }
-                let seq = await counter.next()
                 // The resampler has already aligned this channel's analyzer timeline to
                 // the shared session axis (silence padding at the start and across
                 // rebinds), so the range is the offset directly. A CMTime can be valid
@@ -586,16 +909,20 @@ struct Pipeline {
                     let s = t.seconds
                     return s.isFinite ? s : nil
                 }
+                let audioStart = sessionSeconds(result.range.start)
+                let audioEnd = sessionSeconds(result.range.end)
                 let timing = ChunkTiming(
-                    timestamp: Date(),
-                    audioStart: sessionSeconds(result.range.start),
-                    audioEnd:   sessionSeconds(result.range.end)
+                    timestamp: timestampFor(audioStart),
+                    audioStart: audioStart,
+                    audioEnd: audioEnd
                 )
                 let confidence = aggregateConfidence(result.text)
-                await renderer.handle(.finalized(channel: channel, seq: seq, source: text, timing: timing, confidence: confidence))
-                if willTranslate {
-                    chunkBuilder.yield((seq, text))
-                }
+                await reconciler.receive(ChunkReconciler.Candidate(
+                    locale: locale,
+                    text: text,
+                    timing: timing,
+                    confidence: confidence
+                ))
             } else {
                 await renderer.handle(.volatile(channel: channel, text: text))
             }
@@ -623,16 +950,29 @@ struct Pipeline {
         counter: SeqCounter,
         sessionStart: Double
     ) async throws {
-        let willTranslate = targetLocale != nil
-        let transcriber = SpeechTranscriber(
-            locale: sourceLocale,
-            transcriptionOptions: [],
-            reportingOptions: [.volatileResults, .fastResults],
-            attributeOptions: [.audioTimeRange, .transcriptionConfidence]
-        )
-        let analyzer = SpeechAnalyzer(modules: [transcriber])
+        let willTranslate = targetLocales != nil
 
-        guard let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: [transcriber]) else {
+        // One transcriber + analyzer + bounded input buffer per source locale, same
+        // as runChannel but with BoundedAnalyzerInputBuffer instead of AsyncStream so
+        // file reads are paced end-to-end by the slowest analyzer's drain rate.
+        struct PerLocaleFile {
+            let locale: Locale
+            let transcriber: SpeechTranscriber
+            let analyzer: SpeechAnalyzer
+            let inputBuffer: BoundedAnalyzerInputBuffer
+        }
+        var perLocale: [PerLocaleFile] = []
+        for src in sourceLocales {
+            let t = makeTranscriberStack(for: src)
+            let a = SpeechAnalyzer(modules: [t])
+            // Capacity 8 is enough to absorb short producer / consumer rate mismatches
+            // without ever holding more than a fraction of a second of PCM in memory:
+            // 4096 frames per chunk × 8 ≈ 32 K frames, ~0.67 s at the typical 48 kHz
+            // analyzer format and well under 1 MB for any mono / stereo float32 input.
+            perLocale.append(PerLocaleFile(locale: src, transcriber: t, analyzer: a, inputBuffer: BoundedAnalyzerInputBuffer(capacity: 8)))
+        }
+
+        guard let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: perLocale.map { $0.transcriber }) else {
             throw VoError.noCompatibleAudioFormat
         }
 
@@ -648,18 +988,14 @@ struct Pipeline {
         let stopper: () async -> Void = { source.stop() }
         await stops.register(AsyncStopper(action: stopper))
 
-        // Capacity 8 is enough to absorb short producer / consumer rate mismatches
-        // without ever holding more than a fraction of a second of PCM in memory:
-        // 4096 frames per chunk × 8 ≈ 32 K frames, ~0.67 s at the typical 48 kHz
-        // analyzer format and well under 1 MB for any mono / stereo float32 input.
-        let inputBuffer = BoundedAnalyzerInputBuffer(capacity: 8)
+        let inputBuffers = perLocale.map { $0.inputBuffer }
 
         // Resampler: pull one buffer at a time from the file, bridge gaps with silence
-        // exactly like runChannel does for live capture, and send into the bounded
-        // input. `send` suspends when the buffer is full, so file reads are paced by
-        // the analyzer's drain rate end-to-end. A read failure rethrows as
+        // exactly like runChannel does for live capture, and send into every bounded
+        // input. `send` suspends when any buffer is full, so file reads are paced by
+        // the slowest analyzer's drain rate end-to-end. A read failure rethrows as
         // VoError.inputFileReadFailed; the success path closes the buffer cleanly so
-        // the analyzer's results stream drains and exits.
+        // the analyzers' results streams drain and exit.
         let resampler: Task<Void, Error> = Task.detached { [inputURL] in
             var fedEndHostTime: Double? = nil
             while !Task.isCancelled {
@@ -667,70 +1003,46 @@ struct Pipeline {
                 do {
                     timed = try source.nextBuffer()
                 } catch {
-                    await inputBuffer.finish()
+                    for buf in inputBuffers { await buf.finish() }
                     throw VoError.inputFileReadFailed(url: inputURL, underlying: error)
                 }
                 guard let timed else { break }
                 let reference = fedEndHostTime ?? sessionStart
                 let h = max(timed.hostTime, reference)
                 if let silence = makeSilentBuffer(seconds: h - reference, format: analyzerFormat) {
-                    await inputBuffer.send(AnalyzerInput(buffer: silence))
+                    for buf in inputBuffers { await buf.send(AnalyzerInput(buffer: silence)) }
                 }
                 if let converted = convertBuffer(timed.buffer, to: analyzerFormat) {
-                    await inputBuffer.send(AnalyzerInput(buffer: converted))
+                    for buf in inputBuffers { await buf.send(AnalyzerInput(buffer: converted)) }
                     fedEndHostTime = h + Double(timed.buffer.frameLength) / timed.buffer.format.sampleRate
                 } else {
                     fedEndHostTime = h
                 }
             }
-            await inputBuffer.finish()
+            for buf in inputBuffers { await buf.finish() }
         }
 
         do {
-            try await analyzer.prepareToAnalyze(in: analyzerFormat)
-            try await analyzer.start(inputSequence: inputBuffer)
+            for p in perLocale {
+                try await p.analyzer.prepareToAnalyze(in: analyzerFormat)
+                try await p.analyzer.start(inputSequence: p.inputBuffer)
+            }
         } catch {
             resampler.cancel()
-            await inputBuffer.finish()
+            for buf in inputBuffers { await buf.finish() }
             await stopper()
             throw error
         }
 
-        let (chunkSeq, chunkBuilder) = AsyncStream<(Int, String)>.makeStream()
-        let renderer = renderer
-        let sourceLang = sourceLocale.language
-        let targetLang = targetLocale?.language
-        let translator: Task<Void, Never>? = willTranslate ? Task {
-            guard let targetLang else { return }
-            let box = SendableTranslationSession(inner: TranslationSession(installedSource: sourceLang, target: targetLang))
-            do {
-                try await box.inner.prepareTranslation()
-            } catch is CancellationError {
-                return
-            } catch {}
-            // See makeTranslator(): bounded TaskGroup fan-out. File mode is the
-            // hot path for this -- transcribe finalizes faster than serial translate
-            // can drain, and the commitQueue head stalls until the head's translate
-            // returns. Without this the JSONL stream emits nothing until SIGINT.
-            await withTaskGroup(of: Void.self) { group in
-                var inFlight = 0
-                for await (seq, text) in chunkSeq {
-                    if inFlight >= translateConcurrency {
-                        await group.next()
-                        inFlight -= 1
-                    }
-                    group.addTask {
-                        do {
-                            let response = try await box.inner.translate(text)
-                            await renderer.handle(.translated(seq: seq, target: response.targetText))
-                        } catch {
-                            await renderer.handle(.translated(seq: seq, target: "[translation failed: \(error.localizedDescription)]"))
-                        }
-                    }
-                    inFlight += 1
-                }
+        let lanes: [String: TranslationLane] = makeTranslationLanes()
+        let dstLangByLocale: [String: String] = {
+            guard let targetLocales else { return [:] }
+            var m: [String: String] = [:]
+            for (i, src) in sourceLocales.enumerated() {
+                m[src.identifier(.bcp47)] = targetLocales[i].identifier(.bcp47)
             }
-        } : nil
+            return m
+        }()
 
         // In file mode, anchor timestamp to a "local-TZ epoch" (wall-clock
         // 1970-01-01T00:00:00 in the renderer's local timezone) plus
@@ -752,54 +1064,63 @@ struct Pipeline {
             return cal.date(from: DateComponents(year: 1970, month: 1, day: 1)) ?? Date(timeIntervalSince1970: 0)
         }()
 
+        let rendererRef = renderer
+        let reconciler = ChunkReconciler(nLocales: sourceLocales.count) { winner in
+            let seq = await counter.next()
+            let srcLang = winner.locale.identifier(.bcp47)
+            let dstLang = dstLangByLocale[srcLang]
+            await rendererRef.handle(.finalized(
+                channel: .file,
+                seq: seq,
+                source: winner.text,
+                timing: winner.timing,
+                confidence: winner.confidence,
+                srcLangOverride: srcLang,
+                dstLangOverride: dstLang
+            ))
+            if willTranslate, let lane = lanes[srcLang] {
+                lane.builder.yield((seq, winner.text))
+            }
+        }
+
         do {
-            for try await result in transcriber.results {
-                let text = String(result.text.characters).trimmingCharacters(in: .whitespacesAndNewlines)
-                if result.isFinal {
-                    guard !text.isEmpty else { continue }
-                    let seq = await counter.next()
-                    func sessionSeconds(_ t: CMTime) -> Double? {
-                        guard t.isValid else { return nil }
-                        let s = t.seconds
-                        return s.isFinite ? s : nil
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                for p in perLocale {
+                    group.addTask {
+                        try await self.drainTranscriberResults(
+                            channel: .file,
+                            transcriber: p.transcriber,
+                            locale: p.locale,
+                            reconciler: reconciler,
+                            // A missing audio.start (invalid range) falls back to the
+                            // same anchor as audio.start = 0 (the local-TZ epoch),
+                            // not Unix epoch 00:00Z.
+                            timestampFor: { audioStart in localEpoch.addingTimeInterval(audioStart ?? 0) }
+                        )
                     }
-                    let audioStart = sessionSeconds(result.range.start)
-                    let audioEnd   = sessionSeconds(result.range.end)
-                    // A missing audio.start (invalid range) falls back to
-                    // the same anchor as audio.start = 0 (the local-TZ
-                    // epoch above), not Unix epoch 00:00Z.
-                    let timing = ChunkTiming(
-                        timestamp: localEpoch.addingTimeInterval(audioStart ?? 0),
-                        audioStart: audioStart,
-                        audioEnd:   audioEnd
-                    )
-                    let confidence = aggregateConfidence(result.text)
-                    await renderer.handle(.finalized(channel: .file, seq: seq, source: text, timing: timing, confidence: confidence))
-                    if willTranslate {
-                        chunkBuilder.yield((seq, text))
-                    }
-                } else {
-                    await renderer.handle(.volatile(channel: .file, text: text))
                 }
+                try await group.waitForAll()
             }
         } catch {
             resampler.cancel()
-            // Close the bounded buffer so a resampler suspended in `send` (buffer
+            // Close the bounded buffers so a resampler suspended in `send` (buffer
             // full at the moment the drain threw) is unblocked. Without this, cancel
             // alone leaves the CheckedContinuation unresumed and the resampler task
             // strands, leaking its frame and the buffered AVAudioPCMBuffers.
-            await inputBuffer.finish()
-            chunkBuilder.finish()
-            translator?.cancel()
+            for buf in inputBuffers { await buf.finish() }
+            for lane in lanes.values { lane.builder.finish() }
+            for lane in lanes.values { lane.translator.cancel() }
             await stopper()
+            await reconciler.finish()
             throw error
         }
 
         await stopper()
-        chunkBuilder.finish()
-        await translator?.value
+        await reconciler.finish()
+        for lane in lanes.values { lane.builder.finish() }
+        for lane in lanes.values { await lane.translator.value }
         // The analyzer's results finished because the resampler closed the input
-        // buffer. If the close was preceded by a read failure, that failure is still
+        // buffers. If the close was preceded by a read failure, that failure is still
         // pending on the resampler's value; rethrow it here so a corrupt / truncated
         // file does not surface as a clean exit.
         try await resampler.value
@@ -836,7 +1157,12 @@ struct Pipeline {
     /// framework only downloads via a UI confirmation sheet, which a CLI cannot
     /// present, so an uninstalled pair would otherwise fail silently on every
     /// chunk. Fail fast with install instructions instead.
+    ///
+    /// Same-language pairs (e.g. `ja-JP → ja-JP` in a bidi setup) are a no-op
+    /// passthrough handled in `makeTranslator`; `LanguageAvailability.status`
+    /// reports them as `.unsupported`, which would otherwise abort startup.
     private func ensureTranslationModel(source: Locale, target: Locale) async throws {
+        if isSameLanguage(source, target) { return }
         let status = await LanguageAvailability().status(from: source.language, to: target.language)
         switch status {
         case .installed:
@@ -878,6 +1204,15 @@ private func aggregateConfidence(_ text: AttributedString) -> ChunkConfidence? {
     guard weight > 0 else { return nil }
     let round3 = { (x: Double) in (x * 1000).rounded() / 1000 }
     return ChunkConfidence(mean: round3(weightedSum / Double(weight)), min: round3(lowest))
+}
+
+/// Two locales share the same underlying language. Used to detect the passthrough
+/// case in bidi setups (e.g. `--src en-US,ja-JP --dst ja-JP,ja-JP` where the second
+/// pair is `ja-JP → ja-JP`, meaning leave the source untranslated). Compares the
+/// language code only, so `ja-JP` / `ja` / `ja-Hira-JP` all match.
+private func isSameLanguage(_ a: Locale, _ b: Locale) -> Bool {
+    guard let lhs = a.language.languageCode, let rhs = b.language.languageCode else { return false }
+    return lhs == rhs
 }
 
 /// Current host time in seconds on the mach timebase, matching the `hostTime` that captured

--- a/Sources/vo/Pipeline.swift
+++ b/Sources/vo/Pipeline.swift
@@ -734,14 +734,21 @@ struct Pipeline {
             makeCapture: makeCapture
         )
 
-        // Warm each model / ANE in parallel with the now-flowing capture so the
-        // first finalized chunk comes back in ~1.45 s instead of ~2.2 s. If
-        // any prepare/start throws, the resampler we just spawned would be
-        // orphaned, so cancel it explicitly before propagating.
+        // Warm each model / ANE concurrently — both with the now-flowing capture
+        // and with each other across locales — so the first finalized chunk
+        // comes back in ~1.45 s instead of ~2.2 s and adding source locales does
+        // not multiply startup latency by ANE compile time. If any prepare/start
+        // throws, the resampler we just spawned would be orphaned, so cancel it
+        // explicitly before propagating.
         do {
-            for p in perLocale {
-                try await p.analyzer.prepareToAnalyze(in: analyzerFormat)
-                try await p.analyzer.start(inputSequence: p.inputSeq)
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                for p in perLocale {
+                    group.addTask {
+                        try await p.analyzer.prepareToAnalyze(in: analyzerFormat)
+                        try await p.analyzer.start(inputSequence: p.inputSeq)
+                    }
+                }
+                try await group.waitForAll()
             }
         } catch {
             resampler.cancel()
@@ -1141,10 +1148,18 @@ struct Pipeline {
             for buf in inputBuffers { await buf.finish() }
         }
 
+        // Same parallel warm-up as runChannel: prepareToAnalyze + start fan out
+        // across locales so multi-source file mode does not multiply startup
+        // latency by ANE compile time per locale.
         do {
-            for p in perLocale {
-                try await p.analyzer.prepareToAnalyze(in: analyzerFormat)
-                try await p.analyzer.start(inputSequence: p.inputBuffer)
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                for p in perLocale {
+                    group.addTask {
+                        try await p.analyzer.prepareToAnalyze(in: analyzerFormat)
+                        try await p.analyzer.start(inputSequence: p.inputBuffer)
+                    }
+                }
+                try await group.waitForAll()
             }
         } catch {
             resampler.cancel()

--- a/Sources/vo/Pipeline.swift
+++ b/Sources/vo/Pipeline.swift
@@ -474,9 +474,11 @@ actor VolatileGate {
         let key = locale.identifier(.bcp47)
         let now = Date()
         scores[key] = Score(text: text, mean: mean, receivedAt: now)
-        for (k, v) in scores where now.timeIntervalSince(v.receivedAt) > staleThreshold {
-            scores.removeValue(forKey: k)
-        }
+        // Rebuild the table rather than mutate-while-iterating; Swift's Dictionary
+        // traps with "Dictionary mutated while being enumerated" if we both walk
+        // and remove from the same instance, and this runs on every volatile
+        // partial in multi-locale mode (hot path).
+        scores = scores.filter { _, v in now.timeIntervalSince(v.receivedAt) <= staleThreshold }
         guard let chosen = pickLeader() else { return }
         await renderer.handle(.volatile(channel: channel, text: chosen.text))
     }

--- a/Sources/vo/Pipeline.swift
+++ b/Sources/vo/Pipeline.swift
@@ -275,6 +275,16 @@ actor ChunkReconciler {
     /// audio range (see `recentlyEmittedPruneBoundary`), not wall clock, so a slow
     /// transcriber that lags the fast one by seconds still hits this guard.
     private var recentlyEmitted: [EmittedRegion] = []
+    /// Defensive cap on `recentlyEmitted`. The boundary-based prune only advances
+    /// once every locale has contributed a valid-timing chunk, so a misconfigured
+    /// bidi run where one of the configured locales is never actually spoken
+    /// (transcriber never finalizes anything usable) would otherwise let the list
+    /// grow without bound. On overflow we sort and drop the oldest entries by
+    /// `unionEnd`; a very-late candidate for one of those dropped utterances could
+    /// then double-emit, but the user has long since moved past it. ~1024 entries
+    /// at ~6 utterances/minute is roughly three hours of normal speech before the
+    /// cap kicks in, which means well-configured runs never hit it.
+    private let recentlyEmittedCap = 1024
     /// Latest `audioStart` observed per locale (BCP-47 identifier → max start).
     /// Pruning recentlyEmitted by the *current* candidate's start was unsafe in
     /// multi-source mode: a faster transcriber could advance far enough that
@@ -455,6 +465,14 @@ actor ChunkReconciler {
             unionStart: region.unionStart,
             unionEnd: region.unionEnd
         ))
+        // Apply the defensive cap. In a healthy run the boundary prune above
+        // already keeps recentlyEmitted small, so this overflow path stays
+        // dormant; only triggers in misconfigured bidi where one locale never
+        // contributes a valid-timing finalized chunk.
+        if recentlyEmitted.count > recentlyEmittedCap {
+            recentlyEmitted.sort { $0.unionEnd < $1.unionEnd }
+            recentlyEmitted.removeFirst(recentlyEmitted.count - recentlyEmittedCap)
+        }
 
         await onEmit(winner)
     }

--- a/Sources/vo/Pipeline.swift
+++ b/Sources/vo/Pipeline.swift
@@ -303,8 +303,12 @@ actor ChunkReconciler {
         guard let start = candidate.timing.audioStart,
               let end = candidate.timing.audioEnd,
               end > start else {
-            // No timing → can't overlap-match. Emit standalone rather than swallow.
-            await onEmit(candidate)
+            // No timing → can't overlap-match, so this candidate also can't ride
+            // the recentlyEmitted dedup. Emitting it anyway would let the same
+            // utterance double-emit if another locale produced a valid range for
+            // it. SpeechTranscriber returns invalid / open-ended ranges only on
+            // degenerate inputs in practice, so dropping the candidate is the
+            // right tradeoff for the multi-source "never emits twice" guarantee.
             return
         }
 

--- a/Sources/vo/Pipeline.swift
+++ b/Sources/vo/Pipeline.swift
@@ -528,7 +528,9 @@ actor VolatileGate {
     }
     private let channel: AudioChannel
     private let renderer: any Renderer
-    private let nLocales: Int
+    /// Exposed as nonisolated so callers can skip work (e.g. aggregateConfidence)
+    /// when the gate is going to ignore it. `nLocales` is immutable after init.
+    nonisolated let nLocales: Int
     private let overrideThreshold: Double
     private let staleThreshold: TimeInterval
     private var scores: [String: Score] = [:]
@@ -1144,8 +1146,12 @@ struct Pipeline {
                 // (the attribute is requested but Apple does not guarantee per-run
                 // values mid-recognition); a nil aggregate falls back to mean 0 so
                 // the gate at worst degrades to "first arrival wins" without
-                // crashing the leaderboard comparison.
-                let mean = aggregateConfidence(result.text)?.mean ?? 0
+                // crashing the leaderboard comparison. Skip the aggregation
+                // entirely in single-source mode where the gate ignores the value
+                // (volatile partials are a ~50/sec hot path on live capture).
+                let mean: Double = volatileGate.nLocales > 1
+                    ? (aggregateConfidence(result.text)?.mean ?? 0)
+                    : 0
                 await volatileGate.update(locale: locale, text: text, mean: mean)
             }
         }

--- a/Sources/vo/Pipeline.swift
+++ b/Sources/vo/Pipeline.swift
@@ -624,6 +624,17 @@ struct Pipeline {
         for locale in sourceLocales {
             try await ensureSpeechAsset(locale: locale)
         }
+        // Listen.parseLocaleList already rejects duplicate --src entries at the
+        // CLI boundary, but pin the invariant here so a future caller (a test,
+        // an embedding) gets a clear crash instead of subtle misrouting:
+        // ChunkReconciler's candidate dictionary, `lastSeenStart`, the
+        // dstLangByLocale map, and the translation lanes table are all keyed by
+        // `identifier(.bcp47)`, so a duplicate would silently collapse two
+        // configured pairs into one and break dedup / routing.
+        precondition(
+            Set(sourceLocales.map { $0.identifier(.bcp47) }).count == sourceLocales.count,
+            "Pipeline requires sourceLocales to be unique by BCP-47 identifier; Listen.parseLocaleList enforces this at the CLI boundary."
+        )
         if let targetLocales {
             // Listen.parseLocaleList already rejects unequal --src / --dst lengths
             // at the CLI boundary, but pin the invariant here so a future caller

--- a/Sources/vo/Pipeline.swift
+++ b/Sources/vo/Pipeline.swift
@@ -321,28 +321,54 @@ actor ChunkReconciler {
             return
         }
 
-        if let idx = pendings.firstIndex(where: { p in
-            overlaps(aStart: p.unionStart, aEnd: p.unionEnd, bStart: start, bEnd: end)
-        }) {
+        let overlappingIdxs = pendings.indices.filter { i in
+            overlaps(aStart: pendings[i].unionStart, aEnd: pendings[i].unionEnd, bStart: start, bEnd: end)
+        }
+
+        if let primary = overlappingIdxs.first {
+            // Fold every other overlapping pending into the primary. A bridging
+            // candidate that spans two near-adjacent regions (each opened earlier
+            // by a different locale that did not yet overlap) would otherwise
+            // leave the secondary regions stranded; their timers fire later and
+            // are dropped by the emitWinner check, taking any high-confidence
+            // candidates they held down with them. Merging here keeps the best
+            // candidate per locale across all overlapping regions.
+            for j in overlappingIdxs.dropFirst().reversed() {
+                let other = pendings[j]
+                other.timeoutTask?.cancel()
+                for (key, c) in other.candidates {
+                    if let existing = pendings[primary].candidates[key] {
+                        if (c.confidence?.mean ?? 0) > (existing.confidence?.mean ?? 0) {
+                            pendings[primary].candidates[key] = c
+                        }
+                    } else {
+                        pendings[primary].candidates[key] = c
+                    }
+                }
+                pendings[primary].unionStart = Swift.min(pendings[primary].unionStart, other.unionStart)
+                pendings[primary].unionEnd = Swift.max(pendings[primary].unionEnd, other.unionEnd)
+                pendings.remove(at: j)
+            }
+
             // Same locale arriving twice (e.g. two short fragments from one transcriber
             // overlapping one chunk from the other) keeps the higher-mean one. The
             // alternative — replacing unconditionally — would discard a high-confidence
             // first fragment in favour of a noisy continuation.
             let key = candidate.locale.identifier(.bcp47)
-            if let existing = pendings[idx].candidates[key] {
+            if let existing = pendings[primary].candidates[key] {
                 let existingMean = existing.confidence?.mean ?? 0
                 let newMean = candidate.confidence?.mean ?? 0
                 if newMean > existingMean {
-                    pendings[idx].candidates[key] = candidate
+                    pendings[primary].candidates[key] = candidate
                 }
             } else {
-                pendings[idx].candidates[key] = candidate
+                pendings[primary].candidates[key] = candidate
             }
-            pendings[idx].unionStart = Swift.min(pendings[idx].unionStart, start)
-            pendings[idx].unionEnd = Swift.max(pendings[idx].unionEnd, end)
+            pendings[primary].unionStart = Swift.min(pendings[primary].unionStart, start)
+            pendings[primary].unionEnd = Swift.max(pendings[primary].unionEnd, end)
 
-            if pendings[idx].candidates.count >= nLocales {
-                let region = pendings.remove(at: idx)
+            if pendings[primary].candidates.count >= nLocales {
+                let region = pendings.remove(at: primary)
                 region.timeoutTask?.cancel()
                 await emitWinner(from: region)
             }

--- a/Sources/vo/Pipeline.swift
+++ b/Sources/vo/Pipeline.swift
@@ -414,6 +414,98 @@ actor ChunkReconciler {
     }
 }
 
+/// Per-channel hybrid leaderboard for partial (volatile) transcripts in multi-source
+/// mode. Each locale's transcriber yields its own stream of partial fragments while
+/// it is still recognizing; without arbitration the renderer's per-channel live
+/// region would flip between locales mid-utterance and read as flicker. The gate
+/// sits between `drainTranscriberResults` and the renderer and decides which
+/// fragment to show:
+///
+///   1. **Sticky winner**: prefer the locale that won the most recent finalized
+///      utterance on this channel. Speech tends to stay in one language for
+///      several utterances in a row, so this stays stable across them.
+///   2. **Override**: if another locale's latest volatile mean confidence beats
+///      the sticky winner's by `overrideThreshold` (default 0.15), switch to it.
+///      This catches a real language switch without flipping on close scores.
+///   3. **Staleness**: drop scores older than `staleThreshold` so a transcriber
+///      that went quiet does not strand the live region with old text.
+///
+/// `nLocales == 1` short-circuits straight to the renderer so single-source mode
+/// keeps its existing zero-overhead path.
+actor VolatileGate {
+    private struct Score {
+        let text: String
+        let mean: Double
+        let receivedAt: Date
+    }
+    private let channel: AudioChannel
+    private let renderer: any Renderer
+    private let nLocales: Int
+    private let overrideThreshold: Double
+    private let staleThreshold: TimeInterval
+    private var scores: [String: Score] = [:]
+    private var sticky: String?
+
+    init(
+        channel: AudioChannel,
+        renderer: any Renderer,
+        nLocales: Int,
+        overrideThreshold: Double = 0.15,
+        staleThreshold: TimeInterval = 1.0
+    ) {
+        self.channel = channel
+        self.renderer = renderer
+        self.nLocales = nLocales
+        self.overrideThreshold = overrideThreshold
+        self.staleThreshold = staleThreshold
+    }
+
+    /// Record a partial fragment from one source locale and forward the currently
+    /// preferred fragment (per the sticky / override / staleness rules above) to
+    /// the renderer's live region.
+    func update(locale: Locale, text: String, mean: Double) async {
+        if nLocales == 1 {
+            await renderer.handle(.volatile(channel: channel, text: text))
+            return
+        }
+        let key = locale.identifier(.bcp47)
+        let now = Date()
+        scores[key] = Score(text: text, mean: mean, receivedAt: now)
+        for (k, v) in scores where now.timeIntervalSince(v.receivedAt) > staleThreshold {
+            scores.removeValue(forKey: k)
+        }
+        guard let chosen = pickLeader() else { return }
+        await renderer.handle(.volatile(channel: channel, text: chosen.text))
+    }
+
+    /// Record which locale won the latest finalized utterance. Called from the
+    /// reconciler's emit path so the next utterance's sticky preference matches
+    /// the speaker's most recently confirmed language.
+    func setStickyWinner(_ locale: String) {
+        sticky = locale
+        // Drop the accumulated leaderboard so the next utterance starts on a
+        // clean slate; the sticky alone seeds the next decision until new
+        // volatiles populate the table.
+        scores.removeAll()
+    }
+
+    private func pickLeader() -> Score? {
+        if let sticky, let stickyScore = scores[sticky] {
+            let bestOther = scores
+                .filter { $0.key != sticky }
+                .values
+                .max(by: { $0.mean < $1.mean })
+            if let bestOther, bestOther.mean - stickyScore.mean > overrideThreshold {
+                return bestOther
+            }
+            return stickyScore
+        }
+        // No sticky yet, or the sticky's most recent score aged out of the
+        // table; pick by raw mean among whatever is current.
+        return scores.values.max(by: { $0.mean < $1.mean })
+    }
+}
+
 /// End-to-end pipeline that orchestrates one or more audio channels.
 ///
 /// For each enabled channel:
@@ -658,9 +750,14 @@ struct Pipeline {
             return m
         }()
 
+        let volatileGate = VolatileGate(channel: channel, renderer: renderer, nLocales: sourceLocales.count)
+
         // Reconciler: receives finalized candidates from every per-locale transcriber,
         // picks a winner per utterance, and assigns the renderer's monotonic `seq` at
         // emission time so renderer source-order commit stays unaffected by reconciliation.
+        // It also nudges the VolatileGate's sticky preference toward the winner so the
+        // next utterance's live region defaults to the same language unless a
+        // competing locale clearly outscores it.
         let rendererRef = renderer
         let reconciler = ChunkReconciler(nLocales: sourceLocales.count) { winner in
             let seq = await counter.next()
@@ -678,11 +775,11 @@ struct Pipeline {
             if willTranslate, let lane = lanes[srcLang] {
                 lane.builder.yield((seq, winner.text))
             }
+            await volatileGate.setStickyWinner(srcLang)
         }
 
-        // Drain each transcriber's results concurrently. Volatile updates from every
-        // locale flow straight to the renderer (the live region is per-channel, not
-        // per-locale, so the latest-arriving fragment wins); finalized chunks go to
+        // Drain each transcriber's results concurrently. Volatile updates go through
+        // the gate (per-channel arbitration across locales); finalized chunks go to
         // the reconciler with a wall-clock-now timestamp.
         do {
             try await withThrowingTaskGroup(of: Void.self) { group in
@@ -693,6 +790,7 @@ struct Pipeline {
                             transcriber: p.transcriber,
                             locale: p.locale,
                             reconciler: reconciler,
+                            volatileGate: volatileGate,
                             timestampFor: { _ in Date() }
                         )
                     }
@@ -870,9 +968,10 @@ struct Pipeline {
         }
     }
 
-    /// Drain one transcriber's result stream. Volatile previews flow straight to the
-    /// renderer's per-channel live region; finalized chunks become candidates fed to
-    /// the per-channel `ChunkReconciler`, which picks one winner per utterance across
+    /// Drain one transcriber's result stream. Volatile previews go through the
+    /// per-channel `VolatileGate` (which arbitrates between locales so the live
+    /// region does not flicker); finalized chunks become candidates fed to the
+    /// per-channel `ChunkReconciler`, which picks one winner per utterance across
     /// every source-locale transcriber sharing the channel.
     ///
     /// `timestampFor` returns the wall-clock instant a finalized chunk represents.
@@ -883,9 +982,9 @@ struct Pipeline {
         transcriber: SpeechTranscriber,
         locale: Locale,
         reconciler: ChunkReconciler,
+        volatileGate: VolatileGate,
         timestampFor: @Sendable (Double?) -> Date
     ) async throws {
-        let renderer = renderer
         for try await result in transcriber.results {
             // SpeechTranscriber emits every chunk after the first with a leading
             // space (stream-concatenation artifact). Trim so TTY columns stay
@@ -924,7 +1023,13 @@ struct Pipeline {
                     confidence: confidence
                 ))
             } else {
-                await renderer.handle(.volatile(channel: channel, text: text))
+                // Volatile partials may not always carry transcriptionConfidence
+                // (the attribute is requested but Apple does not guarantee per-run
+                // values mid-recognition); a nil aggregate falls back to mean 0 so
+                // the gate at worst degrades to "first arrival wins" without
+                // crashing the leaderboard comparison.
+                let mean = aggregateConfidence(result.text)?.mean ?? 0
+                await volatileGate.update(locale: locale, text: text, mean: mean)
             }
         }
     }
@@ -1064,6 +1169,8 @@ struct Pipeline {
             return cal.date(from: DateComponents(year: 1970, month: 1, day: 1)) ?? Date(timeIntervalSince1970: 0)
         }()
 
+        let volatileGate = VolatileGate(channel: .file, renderer: renderer, nLocales: sourceLocales.count)
+
         let rendererRef = renderer
         let reconciler = ChunkReconciler(nLocales: sourceLocales.count) { winner in
             let seq = await counter.next()
@@ -1081,6 +1188,7 @@ struct Pipeline {
             if willTranslate, let lane = lanes[srcLang] {
                 lane.builder.yield((seq, winner.text))
             }
+            await volatileGate.setStickyWinner(srcLang)
         }
 
         do {
@@ -1092,6 +1200,7 @@ struct Pipeline {
                             transcriber: p.transcriber,
                             locale: p.locale,
                             reconciler: reconciler,
+                            volatileGate: volatileGate,
                             // A missing audio.start (invalid range) falls back to the
                             // same anchor as audio.start = 0 (the local-TZ epoch),
                             // not Unix epoch 00:00Z.

--- a/Sources/vo/Pipeline.swift
+++ b/Sources/vo/Pipeline.swift
@@ -272,9 +272,17 @@ actor ChunkReconciler {
     private var pendings: [PendingRegion] = []
     /// Audio-range regions that have already been emitted. A late-arriving candidate
     /// that overlaps one of these is dropped to prevent double output. Pruned by
-    /// audio range (see `receive`), not wall clock, so a slow transcriber that lags
-    /// the fast one by seconds still hits this guard.
+    /// audio range (see `recentlyEmittedPruneBoundary`), not wall clock, so a slow
+    /// transcriber that lags the fast one by seconds still hits this guard.
     private var recentlyEmitted: [EmittedRegion] = []
+    /// Latest `audioStart` observed per locale (BCP-47 identifier → max start).
+    /// Pruning recentlyEmitted by the *current* candidate's start was unsafe in
+    /// multi-source mode: a faster transcriber could advance far enough that
+    /// already-emitted regions were dropped before the slower locale caught up,
+    /// letting its late candidate for an earlier utterance create a fresh region
+    /// and double-emit. Tracking per-locale progress lets us drop a region only
+    /// after every locale has moved past it.
+    private var lastSeenStart: [String: Double] = [:]
     private var finished = false
 
     init(
@@ -312,12 +320,15 @@ actor ChunkReconciler {
             return
         }
 
-        // Drop emitted regions that ended at or before this candidate's start;
-        // each transcriber moves monotonically forward, so any future chunk's
-        // audioStart will be >= start, meaning these regions can no longer
-        // overlap anything. This keeps `recentlyEmitted` bounded without a
-        // wall-clock TTL that would race a slow-language transcriber.
-        recentlyEmitted.removeAll { $0.unionEnd <= start }
+        // Track the locale's latest start, then prune recentlyEmitted only past
+        // the slowest locale's progress (`recentlyEmittedPruneBoundary`). A
+        // per-candidate boundary would drop entries before a lagging locale's
+        // late candidate could match them, letting the late candidate form a
+        // fresh region and double-emit.
+        let locKey = candidate.locale.identifier(.bcp47)
+        lastSeenStart[locKey] = Swift.max(lastSeenStart[locKey] ?? 0, start)
+        let bound = recentlyEmittedPruneBoundary()
+        recentlyEmitted.removeAll { $0.unionEnd <= bound }
 
         // A candidate overlapping a recently-emitted region was already represented
         // by an earlier winner; drop to prevent double output.
@@ -425,9 +436,11 @@ actor ChunkReconciler {
         // candidates; two pendings can each survive `receive` (non-overlapping at
         // creation) and then have one expand via a bridging candidate to absorb
         // the other's range before the laggard's timer fires. Without this second
-        // check the laggard would double-emit. Prune by the region's own start so
-        // the list stays bounded across the actor's lifetime.
-        recentlyEmitted.removeAll { $0.unionEnd <= region.unionStart }
+        // check the laggard would double-emit. Use the same per-locale safe
+        // boundary as receive so a slow transcriber's late candidate still finds
+        // its earlier region in recentlyEmitted instead of being treated as new.
+        let bound = recentlyEmittedPruneBoundary()
+        recentlyEmitted.removeAll { $0.unionEnd <= bound }
         if recentlyEmitted.contains(where: { overlaps(aStart: $0.unionStart, aEnd: $0.unionEnd, bStart: region.unionStart, bEnd: region.unionEnd) }) {
             return
         }
@@ -444,6 +457,18 @@ actor ChunkReconciler {
         ))
 
         await onEmit(winner)
+    }
+
+    /// Safe boundary for pruning `recentlyEmitted`. Returns the smallest
+    /// `audioStart` any locale has reported so far; an emitted region with
+    /// `unionEnd <= boundary` can no longer overlap any future candidate from
+    /// any locale (each transcriber moves monotonically forward), so it is safe
+    /// to drop. Returns 0 until every locale has contributed at least one
+    /// valid-timing candidate, because a locale we have not seen yet might
+    /// still send a chunk for an earlier audio range.
+    private func recentlyEmittedPruneBoundary() -> Double {
+        guard lastSeenStart.count >= nLocales else { return 0 }
+        return lastSeenStart.values.min() ?? 0
     }
 
     private func overlaps(aStart: Double, aEnd: Double, bStart: Double, bEnd: Double) -> Bool {

--- a/Sources/vo/Pipeline.swift
+++ b/Sources/vo/Pipeline.swift
@@ -390,6 +390,18 @@ actor ChunkReconciler {
     }
 
     private func emitWinner(from region: PendingRegion) async {
+        // Skip if this region's audio range was already represented by an earlier
+        // emission. The receive-time check only protects against late-arriving
+        // candidates; two pendings can each survive `receive` (non-overlapping at
+        // creation) and then have one expand via a bridging candidate to absorb
+        // the other's range before the laggard's timer fires. Without this second
+        // check the laggard would double-emit. Prune by the region's own start so
+        // the list stays bounded across the actor's lifetime.
+        recentlyEmitted.removeAll { $0.unionEnd <= region.unionStart }
+        if recentlyEmitted.contains(where: { overlaps(aStart: $0.unionStart, aEnd: $0.unionEnd, bStart: region.unionStart, bEnd: region.unionEnd) }) {
+            return
+        }
+
         guard let winner = region.candidates.values.max(by: {
             ($0.confidence?.mean ?? 0) < ($1.confidence?.mean ?? 0)
         }) else { return }

--- a/Sources/vo/Pipeline.swift
+++ b/Sources/vo/Pipeline.swift
@@ -556,8 +556,17 @@ struct Pipeline {
             try await ensureSpeechAsset(locale: locale)
         }
         if let targetLocales {
-            for (src, dst) in zip(sourceLocales, targetLocales) {
-                try await ensureTranslationModel(source: src, target: dst)
+            // Listen.parseLocaleList already rejects unequal --src / --dst lengths
+            // at the CLI boundary, but pin the invariant here so a future caller
+            // that bypasses Listen (a test, an embedding) gets a clear crash
+            // instead of a silently truncated `zip` that skips validation for
+            // some pairs and later traps on `targetLocales[i]` out of bounds.
+            precondition(
+                sourceLocales.count == targetLocales.count,
+                "Pipeline requires sourceLocales.count == targetLocales.count; Listen.parseLocaleList enforces this at the CLI boundary."
+            )
+            for i in sourceLocales.indices {
+                try await ensureTranslationModel(source: sourceLocales[i], target: targetLocales[i])
             }
         }
 

--- a/Sources/vo/Renderer.swift
+++ b/Sources/vo/Renderer.swift
@@ -210,12 +210,17 @@ actor StreamRenderer: Renderer {
             writeLine("\(ttyHeader(pair.timing.timestamp, pair.channel))\(pair.source)")
             if let target {
                 // Skip the translation line in TTY when the (src → dst) is a
-                // passthrough: same locale on both sides and identical text.
-                // JSONL still emits the redundant `dst` because downstream readers
-                // may rely on the schema being uniform across chunks.
+                // passthrough: same language on both sides and identical text.
+                // Compare language subtags so this matches Pipeline.isSameLanguage,
+                // which decides upstream passthrough by language code only.
+                // Otherwise --src ja-JP --dst ja (same language, different region)
+                // would be a passthrough in the translator (text echoed) but the
+                // TTY would still print the redundant line. JSONL still emits the
+                // redundant `dst` because downstream readers may rely on the
+                // schema being uniform across chunks.
                 let srcLang = pair.srcLangOverride ?? self.sourceLang
                 let dstLang = pair.dstLangOverride ?? self.targetLang
-                let isPassthrough = srcLang == dstLang && target == pair.source
+                let isPassthrough = sameLanguageSubtag(srcLang, dstLang) && target == pair.source
                 if !isPassthrough {
                     writeLine("\(sourceColumnPad)\u{001B}[38;5;244m\(target)\u{001B}[0m")
                 }
@@ -225,6 +230,18 @@ actor StreamRenderer: Renderer {
         case .jsonl:
             if let jsonl { writeLine(jsonl) }
         }
+    }
+
+    /// True when two BCP-47 strings name the same primary language regardless of
+    /// region or script (e.g. `ja-JP` matches `ja`). Used to decide TTY passthrough
+    /// suppression consistently with `Pipeline.isSameLanguage`. Returns false when
+    /// either side has no parseable language subtag, so a malformed identifier
+    /// never suppresses output silently.
+    private func sameLanguageSubtag(_ a: String, _ b: String) -> Bool {
+        let aCode = Locale(identifier: a).language.languageCode?.identifier
+        let bCode = Locale(identifier: b).language.languageCode?.identifier
+        guard let aCode, let bCode else { return false }
+        return aCode == bCode
     }
 
     private func buildJSONL(

--- a/Sources/vo/Renderer.swift
+++ b/Sources/vo/Renderer.swift
@@ -27,9 +27,14 @@ struct ChunkConfidence: Sendable {
 }
 
 /// Events fed into Renderer from the pipeline.
+///
+/// `srcLangOverride` / `dstLangOverride` exist for multi-source (auto-detect)
+/// mode, where each finalized chunk's locale is decided per-utterance rather
+/// than fixed by the renderer's constructor. Single-locale callers leave them
+/// nil and the renderer's `sourceLang` / `targetLang` defaults apply.
 enum RenderEvent: Sendable {
     case volatile(channel: AudioChannel, text: String)
-    case finalized(channel: AudioChannel, seq: Int, source: String, timing: ChunkTiming, confidence: ChunkConfidence?)
+    case finalized(channel: AudioChannel, seq: Int, source: String, timing: ChunkTiming, confidence: ChunkConfidence?, srcLangOverride: String? = nil, dstLangOverride: String? = nil)
     case translated(seq: Int, target: String)
     case eof
 }
@@ -57,6 +62,11 @@ actor StreamRenderer: Renderer {
         let source: String
         let timing: ChunkTiming
         let confidence: ChunkConfidence?
+        /// Per-chunk source-locale override (multi-source auto-detect mode). nil
+        /// means fall back to the renderer's constructor-time `sourceLang`.
+        let srcLangOverride: String?
+        /// Per-chunk target-locale override. nil → renderer's `targetLang`.
+        let dstLangOverride: String?
         var target: String?
     }
 
@@ -111,11 +121,11 @@ actor StreamRenderer: Renderer {
             volatileTexts[channel] = text
             if mode == .tty { redrawLiveRegion() }
 
-        case .finalized(let channel, let seq, let source, let timing, let confidence):
+        case .finalized(let channel, let seq, let source, let timing, let confidence, let srcLangOverride, let dstLangOverride):
             volatileTexts[channel] = ""
             finalizedCount += 1
             if translationEnabled {
-                commitQueue.append(Pair(seq: seq, channel: channel, source: source, timing: timing, confidence: confidence, target: nil))
+                commitQueue.append(Pair(seq: seq, channel: channel, source: source, timing: timing, confidence: confidence, srcLangOverride: srcLangOverride, dstLangOverride: dstLangOverride, target: nil))
                 // Drain before redrawing. drainCommitQueue clears the live region
                 // as a side effect, so the reverse order would blank the pending
                 // "(translating…)" lines until the next event arrives.
@@ -124,7 +134,7 @@ actor StreamRenderer: Renderer {
             } else {
                 // No translation: commit immediately, source-only.
                 if mode == .tty { clearLiveRegion() }
-                emitSourceOnly(channel: channel, seq: seq, source: source, timing: timing, confidence: confidence)
+                emitSourceOnly(channel: channel, seq: seq, source: source, timing: timing, confidence: confidence, srcLangOverride: srcLangOverride)
                 if mode == .tty { redrawLiveRegion() }
             }
 
@@ -169,13 +179,13 @@ actor StreamRenderer: Renderer {
         }
     }
 
-    private func emitSourceOnly(channel: AudioChannel, seq: Int, source: String, timing: ChunkTiming, confidence: ChunkConfidence?) {
+    private func emitSourceOnly(channel: AudioChannel, seq: Int, source: String, timing: ChunkTiming, confidence: ChunkConfidence?, srcLangOverride: String?) {
         // Skip the JSONSerialization unless someone is going to consume it. In TTY
         // mode with no transcript sink (e.g. `vo < /dev/null` where stdout is a TTY
         // but stdin isn't, so SessionLog is never opened) the serialized bytes
         // would just be thrown away.
         let jsonl: String? = (mode == .jsonl || logSink != nil)
-            ? buildJSONL(seq: seq, channel: channel, source: source, target: nil, timing: timing, confidence: confidence, includeTarget: false)
+            ? buildJSONL(seq: seq, channel: channel, source: source, target: nil, timing: timing, confidence: confidence, includeTarget: false, srcLangOverride: srcLangOverride, dstLangOverride: nil)
             : nil
 
         if let jsonl { logSink?.append(jsonl) }
@@ -190,7 +200,7 @@ actor StreamRenderer: Renderer {
 
     private func emitCommittedPair(pair: Pair, target: String?) {
         let jsonl: String? = (mode == .jsonl || logSink != nil)
-            ? buildJSONL(seq: pair.seq, channel: pair.channel, source: pair.source, target: target, timing: pair.timing, confidence: pair.confidence, includeTarget: translationEnabled)
+            ? buildJSONL(seq: pair.seq, channel: pair.channel, source: pair.source, target: target, timing: pair.timing, confidence: pair.confidence, includeTarget: translationEnabled, srcLangOverride: pair.srcLangOverride, dstLangOverride: pair.dstLangOverride)
             : nil
 
         if let jsonl { logSink?.append(jsonl) }
@@ -199,7 +209,16 @@ actor StreamRenderer: Renderer {
         case .tty:
             writeLine("\(ttyHeader(pair.timing.timestamp, pair.channel))\(pair.source)")
             if let target {
-                writeLine("\(sourceColumnPad)\u{001B}[38;5;244m\(target)\u{001B}[0m")
+                // Skip the translation line in TTY when the (src → dst) is a
+                // passthrough: same locale on both sides and identical text.
+                // JSONL still emits the redundant `dst` because downstream readers
+                // may rely on the schema being uniform across chunks.
+                let srcLang = pair.srcLangOverride ?? self.sourceLang
+                let dstLang = pair.dstLangOverride ?? self.targetLang
+                let isPassthrough = srcLang == dstLang && target == pair.source
+                if !isPassthrough {
+                    writeLine("\(sourceColumnPad)\u{001B}[38;5;244m\(target)\u{001B}[0m")
+                }
             } else {
                 writeLine("\(sourceColumnPad)\u{001B}[38;5;240m(no translation)\u{001B}[0m")
             }
@@ -215,10 +234,14 @@ actor StreamRenderer: Renderer {
         target: String?,
         timing: ChunkTiming,
         confidence: ChunkConfidence?,
-        includeTarget: Bool
+        includeTarget: Bool,
+        srcLangOverride: String?,
+        dstLangOverride: String?
     ) -> String? {
         var obj: [String: Any] = jsonlBase(seq: seq, channel: channel, timing: timing)
-        var srcObj: [String: Any] = ["lang": sourceLang, "text": source]
+        let srcLang = srcLangOverride ?? self.sourceLang
+        let dstLang = dstLangOverride ?? self.targetLang
+        var srcObj: [String: Any] = ["lang": srcLang, "text": source]
         if let confidence {
             srcObj["confidence"] = [
                 "mean": StreamRenderer.decimal3(confidence.mean),
@@ -227,8 +250,8 @@ actor StreamRenderer: Renderer {
         }
         obj["src"] = srcObj
         if includeTarget {
-            obj["dst"] = target.map { ["lang": targetLang, "text": $0] }
-                ?? ["lang": targetLang, "text": NSNull()]
+            obj["dst"] = target.map { ["lang": dstLang, "text": $0] }
+                ?? ["lang": dstLang, "text": NSNull()]
         }
         return jsonString(obj)
     }

--- a/Sources/vo/Vo.swift
+++ b/Sources/vo/Vo.swift
@@ -11,10 +11,10 @@ struct Vo: AsyncParsableCommand {
 
     // MARK: - Capture options
 
-    @Option(name: .long, help: "Source locale, BCP-47 (e.g. en-US, ja-JP). Defaults to your system locale.")
+    @Option(name: .long, help: "Source locale(s), BCP-47, comma-separated for auto-detect (e.g. en-US,ja-JP). With more than one locale every channel runs a transcriber per locale in parallel and the highest-confidence result wins per utterance. Defaults to your system locale.")
     var src: String = Locale.current.identifier(.bcp47)
 
-    @Option(name: .long, help: "Target locale, BCP-47. Omit to skip translation.")
+    @Option(name: .long, help: "Target locale(s), BCP-47, comma-separated and position-paired with --src (e.g. --src en-US,ja-JP --dst ja-JP,en-US for bidirectional interpretation). Omit to skip translation.")
     var dst: String?
 
     @Flag(name: .long, help: "Disable microphone capture")

--- a/Tests/voTests/RendererTests.swift
+++ b/Tests/voTests/RendererTests.swift
@@ -188,4 +188,65 @@ struct RendererTests {
 
         #expect(src(objs[0])?["confidence"] == nil)
     }
+
+    /// Per-chunk `srcLangOverride` takes precedence over the renderer's
+    /// constructor `sourceLang`. This is how the multi-source reconciler
+    /// surfaces the detected locale per utterance; without the override
+    /// JSONL would always show the constructor default.
+    @Test func srcLangOverrideOverridesConstructorDefault() async {
+        let objs = await renderJSONL(translationEnabled: false) { r in
+            await r.handle(.finalized(channel: .mic, seq: 0, source: "Bonjour", timing: timing, confidence: nil, srcLangOverride: "fr-FR", dstLangOverride: nil))
+        }
+
+        #expect(objs.count == 1)
+        #expect(src(objs[0])?["lang"] as? String == "fr-FR")
+    }
+
+    /// Per-chunk `dstLangOverride` takes precedence over the renderer's
+    /// constructor `targetLang`. Mirrors `srcLangOverride`; both knobs are
+    /// how the bidi pipeline tells the renderer which `(src → dst)` pair the
+    /// per-utterance winner belongs to.
+    @Test func dstLangOverrideOverridesConstructorDefault() async {
+        let objs = await renderJSONL(translationEnabled: true) { r in
+            await r.handle(.finalized(channel: .mic, seq: 0, source: "Hello", timing: timing, confidence: nil, srcLangOverride: nil, dstLangOverride: "zh-CN"))
+            await r.handle(.translated(seq: 0, target: "你好"))
+        }
+
+        #expect(objs.count == 1)
+        #expect(dst(objs[0])?["lang"] as? String == "zh-CN")
+    }
+
+    /// Bidi scenario: a single renderer handles two utterances whose detected
+    /// source / destination locales swap. Each chunk's `src.lang` and
+    /// `dst.lang` reflects its own per-event overrides, not the constructor
+    /// defaults, so a downstream reader sees the actual routing per chunk.
+    @Test func perChunkOverridesSupportBidirectionalRouting() async {
+        let objs = await renderJSONL(translationEnabled: true) { r in
+            await r.handle(.finalized(channel: .mic, seq: 0, source: "Hello", timing: timing, confidence: nil, srcLangOverride: "en-US", dstLangOverride: "ja-JP"))
+            await r.handle(.translated(seq: 0, target: "こんにちは"))
+            await r.handle(.finalized(channel: .speaker, seq: 1, source: "元気ですか", timing: timing, confidence: nil, srcLangOverride: "ja-JP", dstLangOverride: "en-US"))
+            await r.handle(.translated(seq: 1, target: "How are you"))
+        }
+
+        #expect(objs.count == 2)
+        #expect(src(objs[0])?["lang"] as? String == "en-US")
+        #expect(dst(objs[0])?["lang"] as? String == "ja-JP")
+        #expect(src(objs[1])?["lang"] as? String == "ja-JP")
+        #expect(dst(objs[1])?["lang"] as? String == "en-US")
+    }
+
+    /// When neither override is set, the renderer falls back to its
+    /// constructor `sourceLang` / `targetLang`. Single-source mode relies on
+    /// this fallback; spelling it out as a test guards against a future
+    /// refactor that always emits the override values.
+    @Test func nilOverridesFallBackToConstructorDefaults() async {
+        let objs = await renderJSONL(translationEnabled: true) { r in
+            await r.handle(.finalized(channel: .mic, seq: 0, source: "Hello", timing: timing, confidence: nil))
+            await r.handle(.translated(seq: 0, target: "こんにちは"))
+        }
+
+        #expect(objs.count == 1)
+        #expect(src(objs[0])?["lang"] as? String == "en-US")
+        #expect(dst(objs[0])?["lang"] as? String == "ja-JP")
+    }
 }


### PR DESCRIPTION
## Summary

vo previously bound each run to a single `--src` locale, so a session where the speaker(s) switched between two languages had to be split into separate invocations, and per-direction translation (English in to Japanese out, Japanese in to English out) was impossible from one process.

This makes `--src` and `--dst` comma-separated lists, position-paired. Every channel now runs one `SpeechTranscriber` per `--src` locale in parallel and a new `ChunkReconciler` actor picks one winner per utterance: it matches finalized candidates by `audio.range` overlap (> 50% of the shorter side), waits up to 300ms after the first arrival for any remaining locale to contribute, and emits the candidate with the highest `src.confidence.mean`. A 500ms recently-emitted window drops late arrivals so the same utterance never doubles. Translation routing follows the winner to the matching `dst[i]` `TranslationSession`, so

```
vo --src en-US,ja-JP --dst ja-JP,en-US
```

is a single bidirectional interpreter. A same-language pair like `--dst ja-JP,ja-JP` short-circuits the Translation framework (which would reject the pair as unsupported) and echoes the source text as a passthrough; the TTY skips the redundant translation line when both lang and text match.

The single-locale path (`--src en-US --dst ja-JP`) hits a reconciler fast path with no buffering or timer, so its behaviour and latency are unchanged.

## Changes

- `Vo.swift`: update `--src` / `--dst` help text to document the new list syntax.
- `Listen.swift`: split each flag on commas via the new `parseLocaleList` helper, validate matching list lengths, pass `[Locale]` arrays to `Pipeline`. Banner renders the list pair as `en-US,ja-JP → ja-JP,en-US`.
- `Pipeline.swift`:
  - `sourceLocales: [Locale]` / `targetLocales: [Locale]?` replace the single-locale fields. `ensureSpeechAsset` / `ensureTranslationModel` iterate over the lists.
  - `runChannel` and `runFileChannel` build N transcribers + N analyzers per channel; the resampler fans every PCM buffer out to every analyzer input. File mode uses one `BoundedAnalyzerInputBuffer` per locale so the slowest analyzer still paces the file reader.
  - New `ChunkReconciler` actor with the overlap matching + 300ms timeout + 500ms recently-emitted dedup described above.
  - New per-pair `TranslationLane` (translator + chunk pipe), keyed by source-locale BCP-47, so the reconciler routes its winner in O(1).
  - `isSameLanguage` helper + early returns in `ensureTranslationModel` and `makeTranslator` for same-language pairs.
  - `seq` is assigned at reconciler emission time, preserving the renderer's source-order commit invariant.
- `Renderer.swift`: `RenderEvent.finalized` gains optional `srcLangOverride` / `dstLangOverride` (default nil, so existing callers and tests stay unchanged); `Pair` carries them; `buildJSONL` uses overrides when present and falls back to the constructor defaults otherwise. TTY commit suppresses the translation line on passthrough.

## Notes

- Each `SpeechAnalyzer` here holds exactly one `SpeechTranscriber`. Sharing one analyzer across modules with different locales would save a few percent on resampling and ANE warm-up, but per-analyzer isolation is predictable on M-series and easier to reason about. Profiling can revisit later.
- The 300ms timeout and 500ms recently-emitted window are empirical starting values. They can be tuned on real audio without changing the reconciler shape.
- Volatile (in-progress) updates from every locale's transcriber flow to the renderer's per-channel live region as they arrive. The latest fragment wins; some flicker between locales is possible during mid-utterance but is replaced by the committed line on finalize.

## Test plan

- [x] `swift build` clean.
- [x] `./scripts/test.sh` — 22/22 Swift Testing cases still pass (the new override parameters default to nil so existing JSONL fixtures match byte-for-byte).
- [x] CLI rejection: `vo --src en-US,ja-JP --dst ja-JP` errors with `--dst must have the same number of locales as --src (got 2 source, 1 target).`; `vo --src ,en-US` errors with the empty-entry message; `vo --src ""` likewise.
- [x] `vo --help` shows the new comma-separated list syntax and the bidi example in the `--dst` description.
- [x] Manual on macOS 26 hardware (requires Speech / Microphone / Audio Recording TCC grants and both translation models installed via System Settings):
  - [x] `vo --src en-US --dst ja-JP --no-speaker --json` streams finalized chunks identically to `main` (single-locale regression check).
  - [x] `vo --src en-US,ja-JP --no-speaker --json`: speaking English then Japanese alternately yields lines whose `src.lang` follows the spoken language.
  - [x] `vo --src en-US,ja-JP --dst ja-JP,en-US --no-speaker --json`: bidirectional translation; `dst.lang` is always the opposite of `src.lang`.
  - [x] `vo --src en-US,ja-JP --dst ja-JP,ja-JP --no-speaker --json`: English in to ja translation, Japanese in to ja passthrough (`dst.text == src.text`).
  - [ ] `vo --input <mixed-en-ja>.wav --src en-US,ja-JP --dst ja-JP,en-US --json`: file mode end-to-end backpressure still bounded; reconciler picks the right winner per utterance.